### PR TITLE
Fix odometry twist computation

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
     tf
     nav_msgs)
 
+find_package(sophus REQUIRED)
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -15,6 +17,7 @@ catkin_package(
 
 include_directories(
   include ${catkin_INCLUDE_DIRS}
+  include ${sophus_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -19,6 +19,7 @@
   <build_depend>realtime_tools</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>urdf</build_depend>
+  <build_depend>sophus</build_depend>
 
   <run_depend>controller_interface</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -275,8 +275,9 @@ namespace diff_drive_controller{
         odom_pub_->msg_.pose.pose.position.x = odometry_.getX();
         odom_pub_->msg_.pose.pose.position.y = odometry_.getY();
         odom_pub_->msg_.pose.pose.orientation = orientation;
-        odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinear();
-        odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngular();
+        odom_pub_->msg_.twist.twist.linear.x  = odometry_.getVx();
+        odom_pub_->msg_.twist.twist.linear.y  = odometry_.getVy();
+        odom_pub_->msg_.twist.twist.angular.z = odometry_.getVyaw();
         odom_pub_->unlockAndPublish();
       }
 
@@ -522,7 +523,6 @@ namespace diff_drive_controller{
         (0)  (0)  (0)  (static_cast<double>(pose_cov_list[3])) (0)  (0)
         (0)  (0)  (0)  (0)  (static_cast<double>(pose_cov_list[4])) (0)
         (0)  (0)  (0)  (0)  (0)  (static_cast<double>(pose_cov_list[5]));
-    odom_pub_->msg_.twist.twist.linear.y  = 0;
     odom_pub_->msg_.twist.twist.linear.z  = 0;
     odom_pub_->msg_.twist.twist.angular.x = 0;
     odom_pub_->msg_.twist.twist.angular.y = 0;

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -41,6 +41,8 @@
 
 #include <diff_drive_controller/odometry.h>
 
+#include <Eigen/Core>
+
 #include <boost/bind.hpp>
 
 namespace diff_drive_controller
@@ -52,15 +54,17 @@ namespace diff_drive_controller
   , x_(0.0)
   , y_(0.0)
   , heading_(0.0)
-  , linear_(0.0)
-  , angular_(0.0)
+  , v_x_(0.0)
+  , v_y_(0.0)
+  , v_yaw_(0.0)
   , wheel_separation_(0.0)
   , wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
   , velocity_rolling_window_size_(velocity_rolling_window_size)
-  , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
-  , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , v_x_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , v_y_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , v_yaw_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
   {
   }
@@ -68,8 +72,9 @@ namespace diff_drive_controller
   void Odometry::init(const ros::Time& time)
   {
     // Reset accumulators:
-    linear_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
-    angular_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+    v_x_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+    v_y_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+    v_yaw_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
 
     // Reset timestamp:
     timestamp_ = time;
@@ -93,9 +98,36 @@ namespace diff_drive_controller
     const double linear  = (right_wheel_est_vel + left_wheel_est_vel) * 0.5 ;
     const double angular = (right_wheel_est_vel - left_wheel_est_vel) / wheel_separation_;
 
+    /// Safe current state:
+    const SE2 p0(SE2::Scalar(heading_), SE2::Point(x_, y_));
+
     /// Integrate odometry:
     integrate_fun_(linear, angular);
 
+    /// Update twist:
+    const SE2 p1(SE2::Scalar(heading_), SE2::Point(x_, y_));
+
+    return updateTwist(p0, p1, time);
+  }
+
+  bool Odometry::updateOpenLoop(double linear, double angular, const ros::Time &time)
+  {
+    /// Safe current state:
+    const SE2 p0(SE2::Scalar(heading_), SE2::Point(x_, y_));
+
+    /// Integrate odometry:
+    const double dt = (time - timestamp_).toSec();
+    timestamp_ = time;
+    integrate_fun_(linear * dt, angular * dt);
+
+    /// Update twist:
+    const SE2 p1(SE2::Scalar(heading_), SE2::Point(x_, y_));
+
+    return updateTwist(p0, p1, time);
+  }
+
+  bool Odometry::updateTwist(const SE2& p0, const SE2& p1, const ros::Time& time)
+  {
     /// We cannot estimate the speed with very small time intervals:
     const double dt = (time - timestamp_).toSec();
     if(dt < 0.0001)
@@ -103,26 +135,33 @@ namespace diff_drive_controller
 
     timestamp_ = time;
 
-    /// Estimate speeds using a rolling mean to filter them out:
-    linear_acc_(linear/dt);
-    angular_acc_(angular/dt);
+    /// Compute relative transformation:
+    const SE2 p = p0.inverse() * p1;
 
-    linear_ = bacc::rolling_mean(linear_acc_);
-    angular_ = bacc::rolling_mean(angular_acc_);
+    /// Retrieve rotation and translation:
+    /// Note that we don't use the log from SE(2) because we didn't use exp
+    /// to create p0 and p1.
+    /// So instead of:
+    ///
+    ///   const SE2::Tangent v = p.log();
+    ///
+    /// we use the following:
+    const SE2::ConstTranslationReference t = p.translation();
+
+    v_x_   = t[0];
+    v_y_   = t[1];
+    v_yaw_ = p.so2().log();
+
+    /// Estimate speeds using a rolling mean to filter them out:
+    v_x_acc_(v_x_/dt);
+    v_y_acc_(v_y_/dt);
+    v_yaw_acc_(v_yaw_/dt);
+
+    v_x_   = bacc::rolling_mean(v_x_acc_);
+    v_y_   = bacc::rolling_mean(v_y_acc_);
+    v_yaw_ = bacc::rolling_mean(v_yaw_acc_);
 
     return true;
-  }
-
-  void Odometry::updateOpenLoop(double linear, double angular, const ros::Time &time)
-  {
-    /// Save last linear and angular velocity:
-    linear_ = linear;
-    angular_ = angular;
-
-    /// Integrate odometry:
-    const double dt = (time - timestamp_).toSec();
-    timestamp_ = time;
-    integrate_fun_(linear * dt, angular * dt);
   }
 
   void Odometry::setWheelParams(double wheel_separation, double wheel_radius)


### PR DESCRIPTION
The twist is computed as the relative transformation in SE(2) between
the previous and current odometry pose, divided by the time step `dt`.
In order to avoid inconsistencies we avoid the exp and log mappings to  change the translation part of SE(2), so the result is equivalent to using homogeneous matrices, and is valid later in the classical state function of an EKF like in robot_localization package.

The y component of the twist wrt the integration scheme is:
- **Euler**: 0
- **RK2**: != 0, approximately equal to v \* sin(w/2) / dt
- **Exact**: != 0, with an expression more complex than RK2 one.

For RK2 and the Exact integration schemes, the value for y is very small in both cases.
