### PR TITLE
Simplify (and optimized) covariance conversions

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -124,12 +124,11 @@ namespace diff_drive_controller
   static void covarianceToMsg(const Odometry::Covariance& covariance,
       nav_msgs::Odometry::_pose_type::_covariance_type& msg)
   {
-    Eigen::Map<Eigen::Matrix<double, 6, 6> > C(msg.data(), 6, 6);
-    C.block(0, 0, 2, 2) = covariance.block(0, 0, 2, 2);
-    C(5, 5) = covariance(2, 2);
-    C(0, 1) = C(1, 0) = covariance(0, 1);
+    Eigen::Map< Eigen::Matrix<double, 6, 6> > C(msg.data());
+    C.topLeftCorner<2, 2>() = covariance.topLeftCorner<2, 2>();
     C(0, 5) = C(5, 0) = covariance(0, 2);
     C(1, 5) = C(5, 1) = covariance(1, 2);
+    C(5, 5) = covariance(2, 2);
   }
 
   DiffDriveController::DiffDriveController()

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -132,14 +132,11 @@ void msgToCovariance(
     const nav_msgs::Odometry::_pose_type::_covariance_type& msg,
     diff_drive_controller::Odometry::Covariance& covariance)
 {
-  const Eigen::Map<const Eigen::Matrix<double, 6, 6> > C(msg.data(), 6, 6);
-  covariance.block(0, 0, 2, 2) = C.block(0, 0, 2, 2);
+  const Eigen::Map< const Eigen::Matrix<double, 6, 6> > C(msg.data());
+  covariance.topLeftCorner<2, 2>() = C.topLeftCorner<2, 2>();
   covariance(2, 2) = C(5, 5);
 
   // We don't want to ensure symmetry here, for the sake of testing:
-  covariance(0, 1) = C(0, 1);
-  covariance(1, 0) = C(1, 0);
-
   covariance(0, 2) = C(0, 5);
   covariance(2, 0) = C(5, 0);
 


### PR DESCRIPTION
This simply makes a better use of Eigen mapping, replace block with corner operations, use template compile time arguments when possible and remove some repeated operations.

Some operations were enforcing symmetry, but that's already granted on the input covariance matrix.

Another interesting point, that didn't need any action, is that the covariance message has row-major order but Eigen uses col-major order by default. However, this isn't an issue for symmetric matrices.
