### PR TITLE
Add dynamic reconfigure

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -4,6 +4,7 @@ project(diff_drive_controller)
 find_package(catkin REQUIRED
   COMPONENTS
     cmake_modules
+    dynamic_reconfigure
     controller_interface
     urdf
     realtime_tools
@@ -16,6 +17,8 @@ find_package(Eigen REQUIRED)
 find_package(sophus REQUIRED)
 
 find_package(Ceres REQUIRED)
+
+generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -32,6 +35,7 @@ roslint_cpp()
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
 # Note that the entry for ${Ceres_LIBRARIES} was removed as we only used headers from that package
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+PACKAGE = 'diff_drive_controller'
+
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t
+
+gen = ParameterGenerator()
+
+gen.add("wheel_separation_multiplier",  double_t, 0, "Wheel separation multiplier.", 1.0, 0.5, 1.5)
+gen.add("left_wheel_radius_multiplier",  double_t, 0, "Left wheel radius multiplier.", 1.0, 0.5, 1.5)
+gen.add("right_wheel_radius_multiplier",  double_t, 0, "Right wheel radius multiplier.", 1.0, 0.5, 1.5)
+
+gen.add("k_l",  double_t, 0, "Covariance model k_l multiplier.", 1.0, 0.0, 10.0)
+gen.add("k_r",  double_t, 0, "Covariance model k_r multiplier.", 1.0, 0.0, 10.0)
+
+exit(gen.generate(PACKAGE, "diff_drive_controller", "DiffDriveController"))

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -139,9 +139,29 @@ namespace diff_drive_controller
     Odometry odometry_;
     geometry_msgs::TransformStamped odom_frame_;
 
-    /// Dynamic reconfigure server:
+    /// Dynamic reconfigure server related:
     typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
     boost::shared_ptr<ReconfigureServer> cfg_server_;
+
+    struct DynamicParams
+    {
+      double wheel_separation_multiplier;
+      double left_wheel_radius_multiplier;
+      double right_wheel_radius_multiplier;
+
+      double k_l;
+      double k_r;
+
+      DynamicParams()
+        : wheel_separation_multiplier(1.0)
+        , left_wheel_radius_multiplier(1.0)
+        , right_wheel_radius_multiplier(1.0)
+        , k_l(1.0)
+        , k_r(1.0)
+      {}
+    };
+    realtime_tools::RealtimeBuffer<DynamicParams> dynamic_params_;
+    DynamicParams dynamic_params_struct_;
 
     /// Wheel separation, wrt the midpoint of the wheel width:
     double wheel_separation_;

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -46,11 +46,14 @@
 #include <nav_msgs/Odometry.h>
 #include <tf/tfMessage.h>
 
+#include <dynamic_reconfigure/server.h>
+
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
 
 #include <diff_drive_controller/odometry.h>
 #include <diff_drive_controller/speed_limiter.h>
+#include <diff_drive_controller/DiffDriveControllerConfig.h>
 
 #include <vector>
 #include <string>
@@ -136,6 +139,10 @@ namespace diff_drive_controller
     Odometry odometry_;
     geometry_msgs::TransformStamped odom_frame_;
 
+    /// Dynamic reconfigure server:
+    typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
+    boost::shared_ptr<ReconfigureServer> cfg_server_;
+
     /// Wheel separation, wrt the midpoint of the wheel width:
     double wheel_separation_;
 
@@ -179,6 +186,14 @@ namespace diff_drive_controller
      * \param command Velocity command message (twist)
      */
     void cmdVelCallback(const geometry_msgs::Twist& command);
+
+    /**
+     * \brief Reconfigure callback
+     * \param [in, out] config Input new desired configuration and
+     *                         output applied configuration
+     * \param [in]      level  Reconfigure level
+     */
+    void reconfigureCallback(DiffDriveControllerConfig& config, uint32_t level);
 
     /**
      * \brief Get the wheel names from a wheel param

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>realtime_tools</build_depend>
@@ -25,6 +26,7 @@
   <build_depend>libceres-dev</build_depend>
   <build_depend>roslint</build_depend>
 
+  <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>controller_interface</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>realtime_tools</run_depend>


### PR DESCRIPTION
Add dynamic reconfigure (only) for calibration parameters.
This is useful to tune this calibration parameters on the fly.

RT-safe implementation achieved on the second commit.
