### PR TITLE
Make odom publish check robust to time jitter

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -393,7 +393,8 @@ namespace diff_drive_controller
     const ros::Duration half_period(0.5 * period.toSec());
     if (last_state_publish_time_ + publish_period_ < time + half_period)
     {
-      last_state_publish_time_ += publish_period_;
+      last_state_publish_time_ = time;
+
       // Compute and store orientation info
       const geometry_msgs::Quaternion orientation(
             tf::createQuaternionMsgFromYaw(odometry_.getHeading()));

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -390,7 +390,8 @@ namespace diff_drive_controller
     }
 
     // Publish odometry message
-    if (last_state_publish_time_ + publish_period_ < time)
+    const ros::Duration half_period(0.5 * period.toSec());
+    if (last_state_publish_time_ + publish_period_ < time + half_period)
     {
       last_state_publish_time_ += publish_period_;
       // Compute and store orientation info


### PR DESCRIPTION
The current check to publish the odometry sometimes misses one cycle because of the jitter on the `time`.

Consider the following trace where `publish_period_ == 0.002s` (50Hz) and `period == 0.001s` (100Hz):

| call # | `last_state_publish_time_` | `last_state_publish_time_ + publish_period_` | `time` | `last_state_publish_time_ + publish_period_ < time` |
| --- | --- | --- | --- | --- |
| 1 | 0.000 | 0.020 | 0.010 | false |
| 2 | 0.000 | 0.020 | 0.019 | false :bangbang: |
| 3 | 0.000 | 0.020 | 0.029 | true :exclamation: |
| 4 | 0.020 | 0.040 | 0.040 | true |
| 5 | 0.040 | 0.060 | 0.050 | false |
| 6 | 0.040 | 0.060 | 0.061 | true |
| 7 | 0.060 | 0.080 | 0.069 | false |

Additionally, the current implementation doesn't update `last_state_publish_time` with the latest `time`. It the time drifts or jumps it's better to update with the latest `time`. I'm open to have this as an option though.

With this PR the trace would be:

| call # | `last_state_publish_time_` | `last_state_publish_time_ + publish_period_` | `time` | `time + 0.5 * period` | `last_state_publish_time_ + publish_period_ < time + 0.5 * period` |
| --- | --- | --- | --- | --- | --- |
| 1 | 0.000 | 0.020 | 0.010 | 0.015 | false |
| 2 | 0.000 | 0.020 | 0.019 | 0.024 | true |
| 3 | 0.020 | 0.040 | 0.029 | 0.034 | false |
| 4 | 0.020 | 0.040 | 0.040 | 0.045 | true |
| 5 | 0.040 | 0.060 | 0.050 | 0.055 | false |
| 6 | 0.040 | 0.060 | 0.061 | 0.066 | true |
| 7 | 0.060 | 0.080 | 0.069 | 0.074 | false |

**NOTE** The `period` is the time passed since the last call to the `update` method, so it isn't constant. I don't know how to find out the actual update loop frequency.
