### PR TITLE
Publish wheels joint state & limited velocity command

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -4,12 +4,16 @@ project(diff_drive_controller)
 find_package(catkin REQUIRED
   COMPONENTS
     cmake_modules
+    message_generation
     dynamic_reconfigure
     controller_interface
     urdf
     realtime_tools
     tf
+    std_msgs
+    geometry_msgs
     nav_msgs
+    trajectory_msgs
     roslint)
 
 find_package(Boost REQUIRED)
@@ -20,11 +24,24 @@ find_package(sophus REQUIRED)
 
 find_package(Ceres REQUIRED)
 
+add_message_files(
+  FILES
+    DiffDriveControllerState.msg)
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+    trajectory_msgs)
+
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME})
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+    trajectory_msgs)
 
 include_directories(
   include ${catkin_INCLUDE_DIRS}
@@ -38,7 +55,7 @@ roslint_cpp()
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
 # Note that the entry for ${Ceres_LIBRARIES} was removed as we only used headers from that package
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -70,33 +87,49 @@ if (CATKIN_ENABLE_TESTING)
   add_executable(skidsteerbot test/skidsteerbot.cpp)
   target_link_libraries(skidsteerbot ${catkin_LIBRARIES})
 
-  add_dependencies(tests diffbot skidsteerbot)
+  add_dependencies(tests ${PROJECT_NAME} diffbot skidsteerbot)
 
   add_rostest_gtest(diff_drive_test
     test/diff_drive_controller.test
     test/diff_drive_test.cpp)
   target_link_libraries(diff_drive_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
   add_rostest_gtest(diff_drive_nan_test
     test/diff_drive_controller_nan.test
     test/diff_drive_nan_test.cpp)
   target_link_libraries(diff_drive_nan_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_nan_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
   add_rostest_gtest(diff_drive_limits_test
     test/diff_drive_controller_limits.test
     test/diff_drive_limits_test.cpp)
   target_link_libraries(diff_drive_limits_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_limits_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
   add_rostest_gtest(diff_drive_timeout_test
     test/diff_drive_timeout.test
     test/diff_drive_timeout_test.cpp)
   target_link_libraries(diff_drive_timeout_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_timeout_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
   add_rostest(test/diff_drive_multipliers.test)
   add_rostest_gtest(diff_drive_fail_test
     test/diff_drive_wrong.test
     test/diff_drive_fail_test.cpp)
   target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_fail_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
   add_rostest_gtest(diff_drive_odom_tf_test
     test/diff_drive_odom_tf.test
     test/diff_drive_odom_tf_test.cpp)
   target_link_libraries(diff_drive_odom_tf_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_odom_tf_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
+  add_rostest_gtest(diff_drive_publish_state_test
+    test/diff_drive_publish_state.test
+    test/diff_drive_publish_state_test.cpp)
+  target_link_libraries(diff_drive_publish_state_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_publish_state_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
+  add_rostest_gtest(diff_drive_publish_cmd_vel_limited_test
+    test/diff_drive_publish_cmd_vel_limited.test
+    test/diff_drive_publish_cmd_vel_limited_test.cpp)
+  target_link_libraries(diff_drive_publish_cmd_vel_limited_test ${catkin_LIBRARIES})
+  add_dependencies(diff_drive_publish_cmd_vel_limited_test ${${PROJECT_NAME}_EXPORTED_TARGETS})
   add_rostest(test/diff_drive_open_loop.test)
   add_rostest(test/diff_drive_velocity_feedback.test)
   add_rostest(test/skid_steer_controller.test)

--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -2,7 +2,7 @@
 
 PACKAGE = 'diff_drive_controller'
 
-from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, bool_t, double_t
 
 gen = ParameterGenerator()
 
@@ -12,5 +12,8 @@ gen.add("right_wheel_radius_multiplier",  double_t, 0, "Right wheel radius multi
 
 gen.add("k_l",  double_t, 0, "Covariance model k_l multiplier.", 1.0, 0.0, 10.0)
 gen.add("k_r",  double_t, 0, "Covariance model k_r multiplier.", 1.0, 0.0, 10.0)
+
+gen.add("publish_state", bool_t, 0, "Publish joint trajectory controller state.", False)
+gen.add("publish_cmd_vel_limited", bool_t, 0, "Publish limited velocity command.", False)
 
 exit(gen.generate(PACKAGE, "diff_drive_controller", "DiffDriveController"))

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -89,6 +89,10 @@ namespace diff_drive_controller
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+    /// Default diagonal value to initialize the covariance on the constructor:
+    static const double DEFAULT_MINIMUM_TWIST_COVARIANCE;
+    static const double DEFAULT_POSE_COVARIANCE;
+
     /**
      * \brief Constructor
      * Timestamp will get the current time value
@@ -256,13 +260,10 @@ namespace diff_drive_controller
     void setVelocityRollingWindowSize(size_t velocity_rolling_window_size);
 
   private:
+    /// Rolling mean accumulator and window:
+    typedef bacc::accumulator_set<double, bacc::stats<bacc::tag::rolling_mean> > RollingMeanAcc;
+    typedef bacc::tag::rolling_window RollingWindow;
 
-  public:
-    /// Default diagonal value to initialize the covariance on the constructor:
-    static const double DEFAULT_MINIMUM_TWIST_COVARIANCE;
-    static const double DEFAULT_POSE_COVARIANCE;
-
-  private:
     /**
      * \brief Updates the odometry class with latest velocity command and wheel
      * velocities
@@ -292,12 +293,6 @@ namespace diff_drive_controller
      * \param v_r [in] Right wheel velocity displacement [rad]
      */
     void updateMeasCovariance(double v_l, double v_r);
-
-
-  private:
-    /// Rolling mean accumulator and window:
-    typedef bacc::accumulator_set<double, bacc::stats<bacc::tag::rolling_mean> > RollingMeanAcc;
-    typedef bacc::tag::rolling_window RollingWindow;
 
     /**
      * \brief Reset linear and angular accumulators

--- a/diff_drive_controller/msg/DiffDriveControllerState.msg
+++ b/diff_drive_controller/msg/DiffDriveControllerState.msg
@@ -1,0 +1,28 @@
+# This initial part is the same as JointTrajectoryControllerState.msg:
+Header header
+string[] joint_names
+trajectory_msgs/JointTrajectoryPoint desired
+trajectory_msgs/JointTrajectoryPoint actual
+trajectory_msgs/JointTrajectoryPoint error  # Redundant, but useful
+
+# Actual wheel joint trajectory controller state estimated from the positions,
+# i.e. the velocities are NOT the ones directly reported from the joints, but
+# they're differentiated from the positions instead:
+trajectory_msgs/JointTrajectoryPoint actual_estimated
+trajectory_msgs/JointTrajectoryPoint error_estimated  # Redundant, but useful
+
+# Actual wheel joint trajectory controller state averaged for all the wheel
+# joints on each side of the robot, so it can be used on the unicycle model
+# odometry equations; this is the actual state used for the odometry
+# computation if the wheel joint velocity is NOT estimated, but read from the
+# joints:
+trajectory_msgs/JointTrajectoryPoint actual_side_average
+trajectory_msgs/JointTrajectoryPoint error_side_average
+
+# Actual wheel joint trajectory controller state estimated from the positions
+# and averaged for all the wheel joints on each side of the robot, so it can be
+# used on the unicycle model odometry equations; this is the actual state used
+# for the odometry computation if the wheel joint velocity is NOT read from the
+# joints, but estimated:
+trajectory_msgs/JointTrajectoryPoint actual_estimated_side_average
+trajectory_msgs/JointTrajectoryPoint error_estimated_side_average

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -15,9 +15,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>controller_interface</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
   <build_depend>realtime_tools</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>urdf</build_depend>
@@ -27,9 +31,13 @@
   <build_depend>roslint</build_depend>
   <build_depend>boost</build_depend>
 
+  <run_depend>message_runtime</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>controller_interface</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
   <run_depend>realtime_tools</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>urdf</run_depend>
@@ -42,6 +50,7 @@
   <test_depend>controller_manager</test_depend>
   <test_depend>control_toolbox</test_depend>
   <test_depend>xacro</test_depend>
+  <test_depend>rqt_plot</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/diff_drive_controller_plugins.xml"/>

--- a/diff_drive_controller/test/diff_drive_publish_cmd_vel_limited.test
+++ b/diff_drive_controller/test/diff_drive_publish_cmd_vel_limited.test
@@ -1,0 +1,27 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Load diff-drive limits -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_limits.yaml" />
+
+  <!-- Load diff drive parameter publish cmd vel limited -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_publish_cmd_vel_limited.yaml" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_publish_cmd_vel_limited_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_publish_cmd_vel_limited_test"
+        time-limit="20.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="cmd_vel_limited" to="diffbot_controller/cmd_vel_limited" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+
+  <!-- Plot cmd_vel vs. cmd_vel_limited -->
+  <node pkg="rqt_plot" type="rqt_plot" name="plot"
+        args="diffbot_controller/cmd_vel/linear/x
+              diffbot_controller/cmd_vel/angular/z
+              diffbot_controller/cmd_vel_limited/twist/linear/x
+              diffbot_controller/cmd_vel_limited/twist/angular/z"/>
+</launch>

--- a/diff_drive_controller/test/diff_drive_publish_cmd_vel_limited_test.cpp
+++ b/diff_drive_controller/test/diff_drive_publish_cmd_vel_limited_test.cpp
@@ -1,0 +1,120 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Enrique Fernandez
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testInsideLimits)
+{
+  // wait for ROS
+  while (!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  // give some time to the controller to react to the command
+  ros::Duration(0.1).sleep();
+  // send a velocity command of 0.1 m/s and 0.1 rad/s (inside limits)
+  cmd_vel.linear.x = 0.1;
+  cmd_vel.angular.z = 0.1;
+  publish(cmd_vel);
+  // wait a bit (less than the cmd_vel timeout)
+  ros::Duration(1.0).sleep();
+
+  const geometry_msgs::TwistStamped cmd_vel_limited = getLastCmdVelLimited();
+
+  // check cmd_vel limited is the same as the requested one
+  EXPECT_EQ(cmd_vel.linear.x, cmd_vel_limited.twist.linear.x);
+  EXPECT_EQ(cmd_vel.angular.z, cmd_vel_limited.twist.angular.z);
+}
+
+TEST_F(DiffDriveControllerTest, testOutsideLimits)
+{
+  // wait for ROS
+  while (!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  // give some time to the controller to react to the command
+  ros::Duration(0.1).sleep();
+  // send a velocity command of 1.5 m/s and 2.5 rad/s (outside limits)
+  cmd_vel.linear.x = 1.5;
+  cmd_vel.angular.z = 2.5;
+  publish(cmd_vel);
+  // wait a bit (less than the cmd_vel timeout)
+  ros::Duration(2.0).sleep();
+
+  const geometry_msgs::TwistStamped cmd_vel_limited = getLastCmdVelLimited();
+
+  // check cmd_vel limited is smaller than the requested one
+  EXPECT_LT(cmd_vel_limited.twist.linear.x, cmd_vel.linear.x);
+  EXPECT_LT(cmd_vel_limited.twist.angular.z, cmd_vel.angular.z);
+
+  // check cmd_vel limited is equal to the maximum allowed one (limits)
+  double max_linear_velocity = 1.0;
+  double max_angular_velocity = 2.0;
+
+  ros::param::param("/diffbot_controller/linear/x/max_velocity", max_linear_velocity, max_linear_velocity);
+  ros::param::param("/diffbot_controller/angular/z/max_velocity", max_angular_velocity, max_angular_velocity);
+
+  EXPECT_EQ(max_linear_velocity, cmd_vel_limited.twist.linear.x);
+  EXPECT_EQ(max_angular_velocity, cmd_vel_limited.twist.angular.z);
+}
+
+TEST_F(DiffDriveControllerTest, testPreserveTurningRadius)
+{
+  // @todo
+}
+
+TEST_F(DiffDriveControllerTest, testOutsideJointLimits)
+{
+  // @todo
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_publish_cmd_vel_limited_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diff_drive_publish_state.test
+++ b/diff_drive_controller/test/diff_drive_publish_state.test
@@ -1,0 +1,26 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Load diff drive parameter publish joint trajecotry controller state -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_publish_state.yaml" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_publish_state_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_publish_state_test"
+        time-limit="20.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+
+  <!-- Plot desired vs. actual -->
+  <node pkg="rqt_plot" type="rqt_plot" name="plot_position"
+        args="diffbot_controller/state/desired/positions[0]:positions[1],diffbot_controller/state/actual/positions[0]:positions[1]"/>
+
+  <node pkg="rqt_plot" type="rqt_plot" name="plot_velocity"
+        args="diffbot_controller/state/desired/velocities[0]:velocities[1],diffbot_controller/state/actual/velocities[0]:velocities[1]"/>
+
+  <node pkg="rqt_plot" type="rqt_plot" name="plot_acceleration"
+        args="diffbot_controller/state/desired/accelerations[0]:accelerations[1],diffbot_controller/state/actual/accelerations[0]:accelerations[1]"/>
+</launch>

--- a/diff_drive_controller/test/diff_drive_publish_state_test.cpp
+++ b/diff_drive_controller/test/diff_drive_publish_state_test.cpp
@@ -1,0 +1,169 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Enrique Fernandez
+
+#include "test_common.h"
+
+#include <vector>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testError)
+{
+  // wait for ROS
+  while (!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  // give some time to the controller to react to the command
+  ros::Duration(0.1).sleep();
+  // send a velocity command of 0.3 m/s
+  cmd_vel.linear.x = 0.3;
+  publish(cmd_vel);
+  // wait a bit
+  ros::Duration(1.0).sleep();
+
+  diff_drive_controller::DiffDriveControllerState state = getLastState();
+
+  const size_t num_joints = state.error.positions.size();
+  for (size_t i = 0; i < num_joints; ++i)
+  {
+    EXPECT_EQ(state.error.positions[i], state.desired.positions[i] - state.actual.positions[i]);
+    EXPECT_EQ(state.error.velocities[i], state.desired.velocities[i] - state.actual.velocities[i]);
+    EXPECT_EQ(state.error.accelerations[i], state.desired.accelerations[i] - state.actual.accelerations[i]);
+    EXPECT_EQ(state.error.effort[i], state.desired.effort[i] - state.actual.effort[i]);
+  }
+}
+
+TEST_F(DiffDriveControllerTest, testPositionVelocityAcceleration)
+{
+  // wait for ROS
+  while (!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  // give some time to the controller to react to the command
+  ros::Duration(0.1).sleep();
+  // send a velocity command of 0.3 m/s
+  cmd_vel.linear.x = 0.3;
+  publish(cmd_vel);
+  // wait a bit
+  ros::Duration(1.0).sleep();
+
+  std::vector<diff_drive_controller::DiffDriveControllerState> states = getLastStates();
+
+  EXPECT_GT(states.size(), 2);
+
+  const size_t num_states = states.size();
+  std::vector<double> times(num_states);
+  for (size_t i = 0; i < num_states; ++i)
+  {
+    times[i] = states[i].header.stamp.toSec();
+  }
+
+  const size_t num_time_steps = num_states - 1;
+  std::vector<double> time_steps(num_time_steps);
+  for (size_t i = 0; i < num_time_steps; ++i)
+  {
+    time_steps[i] = times[i+1] - times[i];
+  }
+
+  const size_t num_joints = states[0].error.positions.size();
+  for (size_t i = 0; i < num_joints; ++i)
+  {
+    EXPECT_EQ(states[1].error.velocities[i]  , (states[1].error.positions[i]   - states[0].error.positions[i]  ) / time_steps[0]);
+    EXPECT_EQ(states[1].desired.velocities[i], (states[1].desired.positions[i] - states[0].desired.positions[i]) / time_steps[0]);
+    EXPECT_EQ(states[1].actual.velocities[i] , (states[1].actual.positions[i]  - states[0].actual.positions[i] ) / time_steps[0]);
+
+    EXPECT_EQ(states[2].error.velocities[i]  , (states[2].error.positions[i]   - states[1].error.positions[i]  ) / time_steps[1]);
+    EXPECT_EQ(states[2].desired.velocities[i], (states[2].desired.positions[i] - states[1].desired.positions[i]) / time_steps[1]);
+    EXPECT_EQ(states[2].actual.velocities[i] , (states[2].actual.positions[i]  - states[1].actual.positions[i] ) / time_steps[1]);
+
+    EXPECT_EQ(states[1].error.accelerations[i]  , (states[1].error.velocities[i]   - states[0].error.velocities[i]  ) / time_steps[0]);
+    EXPECT_EQ(states[1].desired.accelerations[i], (states[1].desired.velocities[i] - states[0].desired.velocities[i]) / time_steps[0]);
+    EXPECT_EQ(states[1].actual.accelerations[i] , (states[1].actual.velocities[i]  - states[0].actual.velocities[i] ) / time_steps[0]);
+
+    EXPECT_EQ(states[2].error.accelerations[i]  , (states[2].error.velocities[i]   - states[1].error.velocities[i]  ) / time_steps[1]);
+    EXPECT_EQ(states[2].desired.accelerations[i], (states[2].desired.velocities[i] - states[1].desired.velocities[i]) / time_steps[1]);
+    EXPECT_EQ(states[2].actual.accelerations[i] , (states[2].actual.velocities[i]  - states[1].actual.velocities[i] ) / time_steps[1]);
+  }
+}
+
+TEST_F(DiffDriveControllerTest, testZeroErrorSteadyState)
+{
+  // wait for ROS
+  while (!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  // give some time to the controller to react to the command
+  ros::Duration(0.1).sleep();
+  // send a velocity command of 0.3 m/s
+  cmd_vel.linear.x = 0.3;
+  publish(cmd_vel);
+  // wait a bit so we reach the steady state
+  ros::Duration(3.0).sleep();
+
+  diff_drive_controller::DiffDriveControllerState state = getLastState();
+
+  const size_t num_joints = state.error.positions.size();
+  for (size_t i = 0; i < num_joints; ++i)
+  {
+    EXPECT_EQ(state.error.positions[i], 0.0);
+    EXPECT_EQ(state.error.velocities[i], 0.0);
+    EXPECT_EQ(state.error.accelerations[i], 0.0);
+    EXPECT_EQ(state.error.effort[i], 0.0);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diffbot_publish_cmd_vel_limited.yaml
+++ b/diff_drive_controller/test/diffbot_publish_cmd_vel_limited.yaml
@@ -1,0 +1,2 @@
+diffbot_controller:
+  publish_cmd_vel_limited: true

--- a/diff_drive_controller/test/diffbot_publish_state.yaml
+++ b/diff_drive_controller/test/diffbot_publish_state.yaml
@@ -1,0 +1,2 @@
+diffbot_controller:
+  publish_state: true


### PR DESCRIPTION
The wheels joint state publisher allows to compare the actual with the desired velocity.
- The desired positions are computed from the previous and current velocities.
- The desired and actual accelerations are computed from the previous and current velocities.
- The desired effort is set to `NaN`.

The limited velocity command publisher allows to compare the input velocity command and the limited one, before it's converted and sent to the wheels.
- The limited velocity command is assigned the timestamp when it's issued to the wheel, not when the corresponding input velocity was received.
