### PR TITLE
Add Boost dependency

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED
     nav_msgs
     roslint)
 
+find_package(Boost REQUIRED)
+
 find_package(Eigen REQUIRED)
 
 find_package(sophus REQUIRED)
@@ -26,6 +28,7 @@ catkin_package(
 
 include_directories(
   include ${catkin_INCLUDE_DIRS}
+  include ${Boost_INCLUDE_DIRS}
   include ${EIGEN_INCLUDE_DIRS}
   include ${sophus_INCLUDE_DIRS}
   include ${CERES_INCLUDE_DIRS})

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -25,6 +25,7 @@
   <build_depend>sophus</build_depend>
   <build_depend>libceres-dev</build_depend>
   <build_depend>roslint</build_depend>
+  <build_depend>boost</build_depend>
 
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>controller_interface</run_depend>
@@ -32,6 +33,7 @@
   <run_depend>realtime_tools</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>urdf</run_depend>
+  <run_depend>boost</run_depend>
 
   <!--Tests-->
   <build_depend>rostest</build_depend>


### PR DESCRIPTION
This simply adds a missed dependency on Boost.

Note that https://github.com/clearpathrobotics/ros_controllers/pull/13 must be merged before this.
