### PR TITLE
Separate acceleration and deceleration limits.

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -123,13 +123,13 @@ namespace diff_drive_controller
     double min_acceleration;
     double max_acceleration;
 
-    // Deceleration limits
-    double min_deceleration;  // Minimum acceleration used to slow down vehicle to zero velocity.
-    double max_deceleration;  // Maximum acceleration used to slow down vehicle to zero velocity.
-
     // Jerk limits:
     double min_jerk;
     double max_jerk;
+
+    // Deceleration limits
+    double min_deceleration;  // Minimum acceleration used to slow down vehicle to zero velocity.
+    double max_deceleration;  // Maximum acceleration used to slow down vehicle to zero velocity.
   };
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -56,6 +56,8 @@ namespace diff_drive_controller
      * \param [in] max_acceleration Maximum acceleration [m/s^2], usually >= 0
      * \param [in] min_jerk Minimum jerk [m/s^3], usually <= 0
      * \param [in] max_jerk Maximum jerk [m/s^3], usually >= 0
+     * \param [in] min_deceleration Minimum deceleration [m/s^2], usually <= 0
+     * \param [in] max_deceleration Maximum deceleration [m/s^2], usually >= 0
      */
     SpeedLimiter(
       bool has_velocity_limits = false,
@@ -66,7 +68,9 @@ namespace diff_drive_controller
       double min_acceleration = 0.0,
       double max_acceleration = 0.0,
       double min_jerk = 0.0,
-      double max_jerk = 0.0);
+      double max_jerk = 0.0,
+      double min_deceleration = 0.0,
+      double max_deceleration = 0.0);
 
     /**
      * \brief Limit the velocity and acceleration
@@ -118,6 +122,10 @@ namespace diff_drive_controller
     // Acceleration limits:
     double min_acceleration;
     double max_acceleration;
+
+    // Deceleration limits
+    double min_deceleration;  // Minimum acceleration used to slow down vehicle to zero velocity.
+    double max_deceleration;  // Maximum acceleration used to slow down vehicle to zero velocity.
 
     // Jerk limits:
     double min_jerk;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -247,6 +247,8 @@ namespace diff_drive_controller
     controller_nh.param("linear/x/min_velocity"           , limiter_lin_.min_velocity           , -limiter_lin_.max_velocity          );
     controller_nh.param("linear/x/max_acceleration"       , limiter_lin_.max_acceleration       ,  limiter_lin_.max_acceleration      );
     controller_nh.param("linear/x/min_acceleration"       , limiter_lin_.min_acceleration       , -limiter_lin_.max_acceleration      );
+    controller_nh.param("linear/x/max_deceleration"       , limiter_lin_.max_deceleration       ,  limiter_lin_.max_acceleration      );
+    controller_nh.param("linear/x/min_deceleration"       , limiter_lin_.min_deceleration       ,  limiter_lin_.min_acceleration      );
     controller_nh.param("linear/x/max_jerk"               , limiter_lin_.max_jerk               ,  limiter_lin_.max_jerk              );
     controller_nh.param("linear/x/min_jerk"               , limiter_lin_.min_jerk               , -limiter_lin_.max_jerk              );
 
@@ -257,6 +259,8 @@ namespace diff_drive_controller
     controller_nh.param("angular/z/min_velocity"           , limiter_ang_.min_velocity           , -limiter_ang_.max_velocity          );
     controller_nh.param("angular/z/max_acceleration"       , limiter_ang_.max_acceleration       ,  limiter_ang_.max_acceleration      );
     controller_nh.param("angular/z/min_acceleration"       , limiter_ang_.min_acceleration       , -limiter_ang_.max_acceleration      );
+    controller_nh.param("angular/z/max_deceleration"       , limiter_ang_.max_deceleration       ,  limiter_ang_.max_acceleration      );
+    controller_nh.param("angular/z/min_deceleration"       , limiter_ang_.min_deceleration       ,  limiter_ang_.min_acceleration      );
     controller_nh.param("angular/z/max_jerk"               , limiter_ang_.max_jerk               ,  limiter_ang_.max_jerk              );
     controller_nh.param("angular/z/min_jerk"               , limiter_ang_.min_jerk               , -limiter_ang_.max_jerk              );
 

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -102,10 +102,11 @@ namespace diff_drive_controller
   double SpeedLimiter::limit_acceleration(double& v, double v0, double dt)
   {
     const double tmp = v;
-    double dv_min, dv_max, dv;
 
     if (has_acceleration_limits)
     {
+      double dv_min, dv_max, dv;
+
       if (v0 >= 0.0 && v >= 0.0)
       {
         // Moving in positive direction

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -112,37 +112,38 @@ namespace diff_drive_controller
         // Moving in positive direction
         dv_min = min_deceleration * dt;
         dv_max = max_acceleration * dt;
-        dv = clamp(v - v0, dv_min, dv_max);
       }
       else if (v0 <= 0.0 && v <= 0.0)
       {
         // Moving in the negative direction
         dv_min = min_acceleration * dt;
         dv_max = max_deceleration * dt;
-        dv = clamp(v - v0, dv_min, dv_max);
       }
       else
       {
         // Transitioning from positive to negative velocity
         if (v0 > 0)
         {
-          dv = min_deceleration * dt;
+          dv_max = v0;
+          dv_min = min_deceleration * dt;
           if (v0 + dv < 0)
           {
-            dv = min_acceleration * (dt - v0 / min_deceleration);
+            dv_min = min_acceleration * (dt - v0 / min_deceleration);
           }
         }
         // Transitioning from negative to positive velocity
         else if (v0 < 0)
         {
-          dv = max_deceleration * dt;
+          dv_min = v0;
+          dv_max = max_deceleration * dt;
           if (v0 + dv > 0)
           {
-            dv = max_acceleration * (dt - v0 / max_deceleration);
+            dv_max = max_acceleration * (dt - v0 / max_deceleration);
           }
         }
       }
 
+      dv = clamp(v - v0, dv_min, dv_max);
       v = v0 + dv;
     }
 


### PR DESCRIPTION
The current diff_drive_controller suffers a big issue of min_acceleration being both the reverse acceleration and forward deceleration value, and max_acceleration being both the forward acceleration and reverse deceleration value.

This coupling makes it impossible to tune the robots to accelerate slowly, because doing so would cause it to also decelerate slowly in the opposite direction, causing collisions etc.

I've made the changes to backwards compatible as much as I can, which is why the variable names (at least IMO) are a bit confusing. 

@efernandez @servos @mikepurvis @paulbovbel 
