### PR TITLE
Separate odom tf publish time

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -116,6 +116,7 @@ namespace diff_drive_controller
     /// Odometry related:
     ros::Duration publish_period_;
     ros::Time last_odom_publish_time_;
+    ros::Time last_odom_tf_publish_time_;
     bool open_loop_;
 
     bool pose_from_joint_position_;

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -97,22 +97,25 @@ namespace diff_drive_controller
      * \brief Constructor
      * Timestamp will get the current time value
      * Value will be set to zero
-     * \param velocity_rolling_window_size Rolling window size used to compute the velocity mean
+     * \param[in] velocity_rolling_window_size Rolling window size used to
+     *                                         compute the velocity mean
      */
-    explicit Odometry(size_t velocity_rolling_window_size = 10);
+    explicit Odometry(const size_t velocity_rolling_window_size = 10);
 
     /**
      * \brief Initialize the odometry
-     * \param time [in] Current time
+     * \param[in] time Current time
      */
     void init(const ros::Time &time);
 
     /**
      * \brief Updates the odometry class with latest wheels position, i.e. in
      * close loop
-     * \param left_pos  [in] Left  wheel position [rad]
-     * \param right_pos [in] Right wheel position [rad]
-     * \param time      [in] Current time
+     * \param[in] left_position  Left  wheel position [rad]
+     * \param[in] right_position Right wheel position [rad]
+     * \param[in] left_velocity  Left  wheel velocity [rad/s]
+     * \param[in] right_velocity Right wheel velocity [rad/s]
+     * \param[in] time           Current time
      * \return true if the odometry is actually updated
      */
     bool updateCloseLoop(
@@ -123,16 +126,17 @@ namespace diff_drive_controller
     /**
      * \brief Updates the odometry class with latest velocity command, i.e. in
      * open loop
-     * \param linear  [in] Linear  velocity [m/s]
-     * \param angular [in] Angular velocity [rad/s]
-     * \param time    [in] Current time
+     * \param[in] linear  Linear  velocity [m/s]
+     * \param[in] angular Angular velocity [rad/s]
+     * \param[in] time    Current time
      * \return true if the odometry is actually updated
      */
-    bool updateOpenLoop(double linear, double angular, const ros::Time &time);
+    bool updateOpenLoop(const double linear, const double angular,
+        const ros::Time &time);
 
     /**
-     * \brief heading getter
-     * \return heading [rad]
+     * \brief Heading getter
+     * \return Heading [rad]
      */
     double getHeading() const
     {
@@ -185,8 +189,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief pose covariance getter
-     * \return pose covariance
+     * \brief Pose covariance getter
+     * \return Pose covariance
      */
     const PoseCovariance& getPoseCovariance() const
     {
@@ -194,8 +198,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief twist covariance getter
-     * \return twist covariance
+     * \brief Twist covariance getter
+     * \return Twist covariance
      */
     const TwistCovariance& getTwistCovariance() const
     {
@@ -203,8 +207,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief minimum twist covariance getter
-     * \return minimum twist covariance
+     * \brief Minimum twist covariance getter
+     * \return Minimum twist covariance
      */
     const TwistCovariance& getMinimumTwistCovariance() const
     {
@@ -212,8 +216,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief pose covariance setter
-     * \param pose_covariance [in] pose covariance
+     * \brief Pose covariance setter
+     * \param[in] pose_covariance Pose covariance
      */
     void setPoseCovariance(const PoseCovariance& pose_covariance)
     {
@@ -221,8 +225,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief minimum twist covariance setter
-     * \param twist_covariance [in] twist covariance
+     * \brief Minimum twist covariance setter
+     * \param[in] twist_covariance Twist covariance
      */
     void setMinimumTwistCovariance(const TwistCovariance& twist_covariance)
     {
@@ -231,26 +235,27 @@ namespace diff_drive_controller
 
     /**
      * \brief Sets the wheel parameters: radius and separation
-     * \param wheel_separation   [in] Seperation between
-     *                                left and right wheels [m]
-     * \param left_wheel_radius  [in] Left  wheel radius [m]
-     * \param right_wheel_radius [in] Right wheel radius [m]
+     * \param[in] wheel_separation   Seperation between
+     *                               left and right wheels [m]
+     * \param[in] left_wheel_radius  Left  wheel radius [m]
+     * \param[in] right_wheel_radius Right wheel radius [m]
      */
-    void setWheelParams(double wheel_separation,
-        double left_wheel_radius, double right_wheel_radius);
+    void setWheelParams(const double wheel_separation,
+        const double left_wheel_radius, const double right_wheel_radius);
 
     /**
      * \brief Sets the Measurement Covariance Model parameters: k_l and k_r
-     * \param k_l [in] Left  wheel velocity multiplier
-     * \param k_r [in] Right wheel velocity multiplier
+     * \param[in] k_l Left  wheel velocity multiplier
+     * \param[in] k_r Right wheel velocity multiplier
      */
-    void setMeasCovarianceParams(double k_l, double k_r);
+    void setMeasCovarianceParams(const double k_l, const double k_r);
 
     /**
      * \brief Velocity rolling window size setter
      * \param[in] velocity_rolling_window_size Velocity rolling window size
      */
-    void setVelocityRollingWindowSize(size_t velocity_rolling_window_size);
+    void setVelocityRollingWindowSize(
+        const size_t velocity_rolling_window_size);
 
   private:
     /// Rolling mean accumulator and window:
@@ -273,11 +278,11 @@ namespace diff_drive_controller
     /**
      * \brief Update the odometry twist with the previous and current odometry
      * pose
-     * \param p0   [in] Previous odometry pose
-     * \param p1   [in] Current  odometry pose
-     * \param v_l  [in] Left  wheel velocity displacement [rad]
-     * \param v_r  [in] Right wheel velocity displacement [rad]
-     * \param time [in] Current time
+     * \param[in] p0   Previous odometry pose
+     * \param[in] p1   Current  odometry pose
+     * \param[in] v_l  Left  wheel velocity [rad/s]
+     * \param[in] v_r  Right wheel velocity [rad/s]
+     * \param[in] time Current time
      * \return true if the odometry twist is actually updated
      */
     bool updateTwist(const SE2& p0, const SE2& p1,
@@ -285,10 +290,10 @@ namespace diff_drive_controller
 
     /**
      * \brief Update the measurement covariance
-     * \param v_l [in] Left  wheel velocity displacement [rad]
-     * \param v_r [in] Right wheel velocity displacement [rad]
+     * \param[in] dp_l Left  wheel position increment [rad]
+     * \param[in] dp_r Right wheel position increment [rad]
      */
-    void updateMeasCovariance(double v_l, double v_r);
+    void updateMeasCovariance(const double dp_l, const double dp_r);
 
     /**
      * \brief Reset linear and angular accumulators

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -123,13 +123,13 @@ namespace diff_drive_controller
     double min_acceleration;
     double max_acceleration;
 
-    // Deceleration limits
-    double min_deceleration;  // Minimum acceleration used to slow down vehicle to zero velocity.
-    double max_deceleration;  // Maximum acceleration used to slow down vehicle to zero velocity.
-
     // Jerk limits:
     double min_jerk;
     double max_jerk;
+
+    // Deceleration limits
+    double min_deceleration;  // Minimum acceleration used to slow down vehicle to zero velocity.
+    double max_deceleration;  // Maximum acceleration used to slow down vehicle to zero velocity.
   };
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -56,6 +56,8 @@ namespace diff_drive_controller
      * \param [in] max_acceleration Maximum acceleration [m/s^2], usually >= 0
      * \param [in] min_jerk Minimum jerk [m/s^3], usually <= 0
      * \param [in] max_jerk Maximum jerk [m/s^3], usually >= 0
+     * \param [in] min_deceleration Minimum deceleration [m/s^2], usually <= 0
+     * \param [in] max_deceleration Maximum deceleration [m/s^2], usually >= 0
      */
     SpeedLimiter(
       bool has_velocity_limits = false,
@@ -66,7 +68,9 @@ namespace diff_drive_controller
       double min_acceleration = 0.0,
       double max_acceleration = 0.0,
       double min_jerk = 0.0,
-      double max_jerk = 0.0);
+      double max_jerk = 0.0,
+      double min_deceleration = 0.0,
+      double max_deceleration = 0.0);
 
     /**
      * \brief Limit the velocity and acceleration
@@ -118,6 +122,10 @@ namespace diff_drive_controller
     // Acceleration limits:
     double min_acceleration;
     double max_acceleration;
+
+    // Deceleration limits
+    double min_deceleration;  // Minimum acceleration used to slow down vehicle to zero velocity.
+    double max_deceleration;  // Maximum acceleration used to slow down vehicle to zero velocity.
 
     // Jerk limits:
     double min_jerk;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -247,6 +247,8 @@ namespace diff_drive_controller
     controller_nh.param("linear/x/min_velocity"           , limiter_lin_.min_velocity           , -limiter_lin_.max_velocity          );
     controller_nh.param("linear/x/max_acceleration"       , limiter_lin_.max_acceleration       ,  limiter_lin_.max_acceleration      );
     controller_nh.param("linear/x/min_acceleration"       , limiter_lin_.min_acceleration       , -limiter_lin_.max_acceleration      );
+    controller_nh.param("linear/x/max_deceleration"       , limiter_lin_.max_deceleration       ,  limiter_lin_.max_acceleration      );
+    controller_nh.param("linear/x/min_deceleration"       , limiter_lin_.min_deceleration       ,  limiter_lin_.min_acceleration      );
     controller_nh.param("linear/x/max_jerk"               , limiter_lin_.max_jerk               ,  limiter_lin_.max_jerk              );
     controller_nh.param("linear/x/min_jerk"               , limiter_lin_.min_jerk               , -limiter_lin_.max_jerk              );
 
@@ -257,6 +259,8 @@ namespace diff_drive_controller
     controller_nh.param("angular/z/min_velocity"           , limiter_ang_.min_velocity           , -limiter_ang_.max_velocity          );
     controller_nh.param("angular/z/max_acceleration"       , limiter_ang_.max_acceleration       ,  limiter_ang_.max_acceleration      );
     controller_nh.param("angular/z/min_acceleration"       , limiter_ang_.min_acceleration       , -limiter_ang_.max_acceleration      );
+    controller_nh.param("angular/z/max_deceleration"       , limiter_ang_.max_deceleration       ,  limiter_ang_.max_acceleration      );
+    controller_nh.param("angular/z/min_deceleration"       , limiter_ang_.min_deceleration       ,  limiter_ang_.min_acceleration      );
     controller_nh.param("angular/z/max_jerk"               , limiter_ang_.max_jerk               ,  limiter_ang_.max_jerk              );
     controller_nh.param("angular/z/min_jerk"               , limiter_ang_.min_jerk               , -limiter_ang_.max_jerk              );
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -242,8 +242,8 @@ namespace diff_drive_controller
                                    k_r_ * std::abs(v_r);
   }
 
-  void Odometry::setWheelParams(double wheel_separation,
-      double left_wheel_radius, double right_wheel_radius)
+  void Odometry::setWheelParams(const double wheel_separation,
+      const double left_wheel_radius, const double right_wheel_radius)
   {
     wheel_separation_   = wheel_separation;
     left_wheel_radius_  = left_wheel_radius;
@@ -253,14 +253,15 @@ namespace diff_drive_controller
         left_wheel_radius, right_wheel_radius);
   }
 
-  void Odometry::setVelocityRollingWindowSize(size_t velocity_rolling_window_size)
+  void Odometry::setVelocityRollingWindowSize(
+      const size_t velocity_rolling_window_size)
   {
     velocity_rolling_window_size_ = velocity_rolling_window_size;
 
     resetAccumulators();
   }
 
-  void Odometry::setMeasCovarianceParams(double k_l, double k_r)
+  void Odometry::setMeasCovarianceParams(const double k_l, const double k_r)
   {
     k_l_ = k_l;
     k_r_ = k_r;

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -102,10 +102,11 @@ namespace diff_drive_controller
   double SpeedLimiter::limit_acceleration(double& v, double v0, double dt)
   {
     const double tmp = v;
-    double dv_min, dv_max, dv;
 
     if (has_acceleration_limits)
     {
+      double dv_min, dv_max, dv;
+
       if (v0 >= 0.0 && v >= 0.0)
       {
         // Moving in positive direction

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -112,37 +112,38 @@ namespace diff_drive_controller
         // Moving in positive direction
         dv_min = min_deceleration * dt;
         dv_max = max_acceleration * dt;
-        dv = clamp(v - v0, dv_min, dv_max);
       }
       else if (v0 <= 0.0 && v <= 0.0)
       {
         // Moving in the negative direction
         dv_min = min_acceleration * dt;
         dv_max = max_deceleration * dt;
-        dv = clamp(v - v0, dv_min, dv_max);
       }
       else
       {
         // Transitioning from positive to negative velocity
         if (v0 > 0)
         {
-          dv = min_deceleration * dt;
+          dv_max = v0;
+          dv_min = min_deceleration * dt;
           if (v0 + dv < 0)
           {
-            dv = min_acceleration * (dt - v0 / min_deceleration);
+            dv_min = min_acceleration * (dt - v0 / min_deceleration);
           }
         }
         // Transitioning from negative to positive velocity
         else if (v0 < 0)
         {
-          dv = max_deceleration * dt;
+          dv_min = v0;
+          dv_max = max_deceleration * dt;
           if (v0 + dv > 0)
           {
-            dv = max_acceleration * (dt - v0 / max_deceleration);
+            dv_max = max_acceleration * (dt - v0 / max_deceleration);
           }
         }
       }
 
+      dv = clamp(v - v0, dv_min, dv_max);
       v = v0 + dv;
     }
 


### PR DESCRIPTION
This PR is on top of #18 

This adds two things:
1. Use separate odom topic and odom tf publish time variables, because they use different real time publisher, calling to their respective `trylock()` methods, so in some corners cases one can get called in a given cycle but not the other.
2. Homogenize some variable names (mainly `v_` into `dp_` when they don't represent velocities, but "differences of position") and enforce constness where possible; in `odometry.h` the changes are only of this kind in this PR.

@paulbovbel @servos @afakihcpr 
