### PR TITLE
Add control_frequency_desired param

### DIFF
--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -19,4 +19,6 @@ gen.add("k_r",  double_t, 0, "Covariance model k_r multiplier.", 1.0, 0.0, 10.0)
 gen.add("publish_cmd_vel_limited", bool_t, 0, "Publish limited velocity command.", False)
 gen.add("publish_state", bool_t, 0, "Publish joint trajectory controller state.", False)
 
+gen.add("control_frequency_desired",  double_t, 0, "Desired/Expected control frequency [Hz].", 0.0, 0.0, 500.0)
+
 exit(gen.generate(PACKAGE, "diff_drive_controller", "DiffDriveController"))

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -200,6 +200,8 @@ namespace diff_drive_controller
       bool publish_state;
       bool publish_cmd_vel_limited;
 
+      double control_frequency_desired;
+
       DynamicParams()
         : pose_from_joint_position(true)
         , twist_from_joint_position(false)
@@ -210,6 +212,7 @@ namespace diff_drive_controller
         , k_r(1.0)
         , publish_state(false)
         , publish_cmd_vel_limited(false)
+        , control_frequency_desired(0.0)
       {}
     };
     realtime_tools::RealtimeBuffer<DynamicParams> dynamic_params_;
@@ -261,6 +264,15 @@ namespace diff_drive_controller
     /// isn't RT-safe, so we cannot implement a lazy publisher with:
     /// state_pub_->getNumSubscribers() > 0
     bool publish_state_;
+
+    /// Desired control frequency [Hz] (and corresponding period [s]):
+    /// This can be used when the actual/real control frequency/period has too
+    /// much jitter.
+    /// If !(control_frequency_desired_ > 0.0), the actual/real
+    /// frequency/period provided on the update hook (method) is used, which is
+    /// the default and preferred behaviour in general.
+    double control_frequency_desired_;
+    double control_period_desired_;
 
   private:
     /**

--- a/diff_drive_controller/msg/DiffDriveControllerState.msg
+++ b/diff_drive_controller/msg/DiffDriveControllerState.msg
@@ -26,3 +26,8 @@ trajectory_msgs/JointTrajectoryPoint error_side_average
 # joints, but estimated:
 trajectory_msgs/JointTrajectoryPoint actual_estimated_side_average
 trajectory_msgs/JointTrajectoryPoint error_estimated_side_average
+
+# Control period:
+float64 control_period_desired
+float64 control_period_actual
+float64 control_period_error

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -131,6 +131,8 @@ namespace diff_drive_controller
     //
     // this method would be use here and to 'Compute wheels velocities' in
     // diff_drive_controller; here is displacement, there is velocity
+    //double v_l, v_r;
+    //inverseKinematics(linear, angular, v_l, v_r);
     const double v_l = (linear - angular * wheel_separation_ / 2.0) / left_wheel_radius_;
     const double v_r = (linear + angular * wheel_separation_ / 2.0) / right_wheel_radius_;
 


### PR DESCRIPTION
This PR is on top of #19 

This adds the `control_frequency_desired` param, which specifies the desired or expected control frequency.
- It defaults to `0.0`, meaning that the actual control frequency (as provided in the `update` method `period` argument) is used.
- If `> 0.0`, the desired/expected frequency (period) is used instead.

This should help when the time jitter is very high, and also allows to compare the desired vs. actual control period using the **controller state**, which is extended in this PR to include them.

@paulbovbel @afakihcpr 
