### PR TITLE
Add timing to state

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -16,7 +16,9 @@ find_package(catkin REQUIRED
     trajectory_msgs
     roslint)
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED
+  COMPONENTS
+    timer)
 
 find_package(Eigen REQUIRED)
 
@@ -54,7 +56,7 @@ roslint_cpp()
 
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
 # Note that the entry for ${Ceres_LIBRARIES} was removed as we only used headers from that package
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
 install(TARGETS ${PROJECT_NAME}

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -57,6 +57,8 @@
 #include <diff_drive_controller/speed_limiter.h>
 #include <diff_drive_controller/DiffDriveControllerConfig.h>
 
+#include <boost/timer/timer.hpp>
+
 #include <vector>
 #include <string>
 
@@ -184,6 +186,9 @@ namespace diff_drive_controller
     /// Dynamic reconfigure server related:
     typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
     boost::shared_ptr<ReconfigureServer> cfg_server_;
+
+    /// Timing related:
+    boost::timer::cpu_timer cpu_timer_;
 
     struct DynamicParams
     {

--- a/diff_drive_controller/msg/DiffDriveControllerState.msg
+++ b/diff_drive_controller/msg/DiffDriveControllerState.msg
@@ -31,3 +31,18 @@ trajectory_msgs/JointTrajectoryPoint error_estimated_side_average
 float64 control_period_desired
 float64 control_period_actual
 float64 control_period_error
+
+# Control time (of the actual code):
+# Note that the resolution of the wall time is approx. 0.5us, but the user and
+# system is only 10ms. See:
+# http://www.boost.org/doc/libs/1_48_0/libs/timer/doc/cpu_timers.html#Resolution
+#
+# For this reason, and given that the control time is much less than 10ms,
+# the user and system time aren't accurate; note that we can't take an average
+# of multiple cycles because we still have to call stop at the end of the cycle,
+# so the internal count of the timer would still be wrong.
+# Consequently, ignore the user and system time, unless the wall time becomes
+# greater than 10ms.
+float64 control_time_wall
+float64 control_time_user
+float64 control_time_system


### PR DESCRIPTION
This PR is on top of #20 

This simply adds a `boost::cpu_timer` to compute the actual control time in the `update` method (control loop). The user, system and wall time are published on the **controller state** in order to compare them with the control period (desired/expected and actual), which #20 adds to the state too.

@afakihcpr 
