### PR TITLE
Use dynamic params defaults

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -44,10 +44,12 @@ catkin_package(
     trajectory_msgs)
 
 include_directories(
-  include ${catkin_INCLUDE_DIRS}
-  include ${Boost_INCLUDE_DIRS}
-  include ${EIGEN_INCLUDE_DIRS}
-  include ${CERES_INCLUDE_DIRS})
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${EIGEN_INCLUDE_DIRS}
+  ${sophus_INCLUDE_DIRS}
+  ${CERES_INCLUDE_DIRS})
 
 roslint_cpp()
 

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -22,8 +22,6 @@ find_package(Boost REQUIRED
 
 find_package(Eigen REQUIRED)
 
-find_package(sophus REQUIRED)
-
 find_package(Ceres REQUIRED)
 
 add_message_files(

--- a/diff_drive_controller/include/diff_drive_controller/covariance.h
+++ b/diff_drive_controller/include/diff_drive_controller/covariance.h
@@ -41,6 +41,8 @@
 
 #include <Eigen/Dense>
 
+#include <boost/array.hpp>
+
 #include <limits>
 
 namespace diff_drive_controller

--- a/diff_drive_controller/include/diff_drive_controller/covariance.h
+++ b/diff_drive_controller/include/diff_drive_controller/covariance.h
@@ -222,21 +222,22 @@ static void msgToCovariance(
 }
 
 /**
- * \brief Check is a matrix M is symmetric, i.e. M' M = Id or low(M) = up(M)
+ * \brief Check is a matrix M is symmetric, i.e. M' M == Id or low(M) == up(M)
  * where low and up are the lower and upper triangular matrices of M
  * \param [in] M Square matrix
  * \return True if the matrix is symmetric
  */
 template <typename T, int N>
-bool isSymmetric(const Eigen::Matrix<T, N, N>& M)
+bool isSymmetric(const Eigen::Matrix<T, N, N>& M,
+    const double eps = std::numeric_limits<T>::epsilon())
 {
-  // Note that triangularView doesn't help to much to simplify the check,
-  // so we iterate on the lower and upper triangular matrixes directly:
+  // Note that triangularView doesn't help too much to simplify the check,
+  // so we iterate on the lower and upper triangular matrices directly:
   for (size_t i = 0; i < N - 1; ++i)
   {
     for (size_t j = i + 1; j < N; ++j)
     {
-      if (std::abs(M(i, j) - M(j, i)) > std::numeric_limits<T>::epsilon())
+      if (std::abs(M(i, j) - M(j, i)) > eps)
       {
         return false;
       }
@@ -339,7 +340,9 @@ T conditionNumber(const Eigen::Matrix<T, N, N>& M)
 
   const T s_min = svd.singularValues().minCoeff();
 
-  return s_min == 0 ?
+  // Note that the singular values computed with Jacobi SVD are all positive, so
+  // we don't need to use abs().
+  return s_min == T(0) ?
          std::numeric_limits<T>::infinity() :
          svd.singularValues().maxCoeff() / s_min;
 }

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -190,6 +190,8 @@ namespace diff_drive_controller
     typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
     boost::shared_ptr<ReconfigureServer> cfg_server_;
 
+    static const DiffDriveControllerConfig config_default_;
+
     /// Timing related:
     boost::timer::cpu_timer cpu_timer_;
 

--- a/diff_drive_controller/include/diff_drive_controller/integrate_function.h
+++ b/diff_drive_controller/include/diff_drive_controller/integrate_function.h
@@ -56,7 +56,6 @@ namespace diff_drive_controller
 
       /**
        * \brief Constructor
-       * \param [in] functor Integrate functor
        */
       IntegrateFunction()
       {}

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -44,7 +44,6 @@
 
 #include <ros/time.h>
 #include <Eigen/Core>
-#include <sophus/se2.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/rolling_mean.hpp>
@@ -65,9 +64,6 @@ namespace diff_drive_controller
   class Odometry
   {
   public:
-    /// SO(2) and SE(2) Lie Groups:
-    typedef Sophus::SE2d SE2;
-
     /// Covariance matrices:
     typedef Eigen::Matrix3d Covariance;
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -104,24 +104,24 @@ namespace diff_drive_controller
      * \param[in] right_position Right wheel position [rad]
      * \param[in] left_velocity  Left  wheel velocity [rad/s]
      * \param[in] right_velocity Right wheel velocity [rad/s]
-     * \param[in] time           Current time
+     * \param[in] dt             Time step (control period) [s]
      * \return true if the odometry is actually updated
      */
     bool updateCloseLoop(
         const double left_position, const double right_position,
         const double left_velocity, const double right_velocity,
-        const ros::Time &time);
+        const double dt);
 
     /**
      * \brief Updates the odometry class with latest velocity command, i.e. in
      * open loop
      * \param[in] linear  Linear  velocity [m/s]
      * \param[in] angular Angular velocity [rad/s]
-     * \param[in] time    Current time
+     * \param[in] dt      Time step (control period) [s]
      * \return true if the odometry is actually updated
      */
     bool updateOpenLoop(const double linear, const double angular,
-        const ros::Time &time);
+        const double dt);
 
     /**
      * \brief Update the odometry twist with the (internal) incremental pose,
@@ -273,11 +273,11 @@ namespace diff_drive_controller
      * \param[in] dp_r  Right wheel position increment [rad]
      * \param[in] v_l   Left  wheel velocity [rad/s]
      * \param[in] v_r   Right wheel velocity [rad/s]
-     * \param[in] time  Current time
+     * \param[in] dt    Time step (control period) [s]
      * \return true if the odometry is actually updated
      */
     bool update(const double dp_l, const double dp_r,
-        const double v_l, const double v_r, const ros::Time& time);
+        const double v_l, const double v_r, const double dt);
 
     /**
      * \brief Updates the (internal) incremental odometry with latest left and
@@ -291,9 +291,6 @@ namespace diff_drive_controller
      * \brief Reset linear and angular accumulators
      */
     void resetAccumulators();
-
-    /// Current timestamp:
-    ros::Time timestamp_;
 
     /// Timestamp for last twist computed, ie. since when the (internal)
     /// incremental pose has been computed:

--- a/diff_drive_controller/include/diff_drive_controller/rigid_body_motion.h
+++ b/diff_drive_controller/include/diff_drive_controller/rigid_body_motion.h
@@ -78,6 +78,8 @@ static void integrate_motion(double& x, double &y, double &yaw,
  * \param[in] v_y   Velocity/Twist y   component
  * \param[in] v_yaw Velocity/Twist yaw component
  * \param[in] dt Time step
+ * \param[out] J_pose Jacobian wrt the pose
+ * \param[out] J_twist Jacobian wrt the velocity/twist
  */
 static void integrate_motion(double& x, double &y, double &yaw,
     const double v_x, const double v_y, const double v_yaw,

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -26,7 +26,6 @@
   <build_depend>tf</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>sophus</build_depend>
   <build_depend>libceres-dev</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>boost</build_depend>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -120,29 +120,30 @@ static bool getWheelRadius(
 
 namespace diff_drive_controller
 {
+  const DiffDriveControllerConfig DiffDriveController::config_default_ = DiffDriveControllerConfig::__getDefault__();
 
   DiffDriveController::DiffDriveController()
     : open_loop_(false)
-    , pose_from_joint_position_(true)
-    , twist_from_joint_position_(false)
+    , pose_from_joint_position_(config_default_.pose_from_joint_position)
+    , twist_from_joint_position_(config_default_.twist_from_joint_position)
     , command_struct_()
     , dynamic_params_struct_()
     , wheel_separation_(0.0)
     , wheel_radius_(0.0)
-    , wheel_separation_multiplier_(1.0)
-    , left_wheel_radius_multiplier_(1.0)
-    , right_wheel_radius_multiplier_(1.0)
-    , k_l_(0.01)
-    , k_r_(0.01)
-    , wheel_resolution_(0.0)
+    , wheel_separation_multiplier_(config_default_.wheel_separation_multiplier)
+    , left_wheel_radius_multiplier_(config_default_.left_wheel_radius_multiplier)
+    , right_wheel_radius_multiplier_(config_default_.right_wheel_radius_multiplier)
+    , k_l_(config_default_.k_l)
+    , k_r_(config_default_.k_r)
+    , wheel_resolution_(config_default_.wheel_resolution)
     , cmd_vel_timeout_(0.5)
     , base_frame_id_("base_link")
     , enable_odom_tf_(true)
     , wheel_joints_size_(0)
-    , publish_cmd_vel_limited_(false)
-    , publish_state_(false)
-    , control_frequency_desired_(0.0)
-    , control_period_desired_(0.0)
+    , publish_cmd_vel_limited_(config_default_.publish_cmd_vel_limited)
+    , publish_state_(config_default_.publish_state)
+    , control_frequency_desired_(config_default_.control_frequency_desired)
+    , control_period_desired_(1.0 / control_frequency_desired_)
   {
   }
 
@@ -370,8 +371,29 @@ namespace diff_drive_controller
 
     setOdomPubFields(root_nh, controller_nh);
 
-    // Set dynamic reconfigure server callback:
+    // Set dynamic reconfigure params defaults to the static params provided:
+    DiffDriveControllerConfig config;
+    config.pose_from_joint_position = pose_from_joint_position_;
+    config.twist_from_joint_position = twist_from_joint_position_;
+
+    config.wheel_separation_multiplier = wheel_separation_multiplier_;
+
+    config.left_wheel_radius_multiplier = left_wheel_radius_multiplier_;
+    config.right_wheel_radius_multiplier = right_wheel_radius_multiplier_;
+
+    config.k_l = k_l_;
+    config.k_r = k_r_;
+
+    config.wheel_resolution = wheel_resolution_;
+
+    config.publish_state = publish_state_;
+    config.publish_cmd_vel_limited = publish_cmd_vel_limited_;
+
+    dynamic_params_struct_.control_frequency_desired = config.control_frequency_desired;
+
+    // Set dynamic reconfigure server config and callback:
     cfg_server_.reset(new ReconfigureServer(controller_nh));
+    cfg_server_->updateConfig(config);
     cfg_server_->setCallback(
         boost::bind(&DiffDriveController::reconfigureCallback, this, _1, _2));
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -278,7 +278,7 @@ namespace diff_drive_controller
 
     controller_nh.param("publish_state", publish_state_, publish_state_);
     ROS_INFO_STREAM_NAMED(name_,
-        "Publishing the joint trajectory controller state is "
+        "Publishing the controller state is "
         << (publish_state_?"enabled":"disabled"));
 
     controller_nh.param("control_frequency_desired", control_frequency_desired_, control_frequency_desired_);

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -629,11 +629,11 @@ namespace diff_drive_controller
     // Update odometry:
     if (open_loop_)
     {
-      odometry_.updateOpenLoop(last0_cmd_.lin, last0_cmd_.ang, time);
+      odometry_.updateOpenLoop(last0_cmd_.lin, last0_cmd_.ang, control_period);
     }
     else
     {
-      odometry_.updateCloseLoop(left_position, right_position, left_velocity, right_velocity, time);
+      odometry_.updateCloseLoop(left_position, right_position, left_velocity, right_velocity, control_period);
     }
 
     // Publish odometry message:

--- a/diff_drive_controller/src/linear_meas_covariance_model.cpp
+++ b/diff_drive_controller/src/linear_meas_covariance_model.cpp
@@ -66,6 +66,8 @@ LinearMeasCovarianceModel::compute(const double dp_l, const double dp_r)
   /// Set covariance matrix (diagonal):
   meas_covariance_.diagonal() << dp_var_l + dp_var_avg,
                                  dp_var_r + dp_var_avg;
+
+  return meas_covariance_;
 }
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/src/quadratic_meas_covariance_model.cpp
+++ b/diff_drive_controller/src/quadratic_meas_covariance_model.cpp
@@ -70,6 +70,8 @@ QuadraticMeasCovarianceModel::compute(const double dp_l, const double dp_r)
   /// Set covariance matrix (diagonal):
   meas_covariance_.diagonal() << dp_var_l + dp_var_avg,
                                  dp_var_r + dp_var_avg;
+
+  return meas_covariance_;
 }
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/test/diff_drive_test.cpp
+++ b/diff_drive_controller/test/diff_drive_test.cpp
@@ -114,40 +114,17 @@ TEST_F(DiffDriveControllerTest, testNoMove)
 
   // check we have a positive definite covariance matrix
   // isCovariance = isSymmetric + isPositiveDefinite
-  const Eigen::IOFormat HeavyFmt(
-      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
-
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver(pose_covariance);
-  TwistEigenSolver twist_eigensolver(twist_covariance);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance, no_tag()))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance, no_tag()))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
+  testCovariance(pose_covariance, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
 
   // when the robot doesn't move the twist covariance should be exactly the
   // minimum twist covariance, which is defined as a diagonal covariance matrix
   // like this:
   //   Odometry::DEFAULT_MINIMUM_TWIST_COVARIANCE * TwistCovariance::Identity()
   // where Odometry::DEFAULT_MINIMUM_TWIST_COVARIANCE == 1e-9
+  const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
   TwistCovariance minimum_twist_covariance = 1e-9 * TwistCovariance::Identity();
   EXPECT_TRUE(((twist_covariance - minimum_twist_covariance).array() == 0).all())
     << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
@@ -306,34 +283,8 @@ TEST_F(DiffDriveControllerTest, testForward)
 
   // check we have a positive definite covariance matrix
   // isCovariance = isSymmetric + isPositiveDefinite
-  const Eigen::IOFormat HeavyFmt(
-      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
-
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver(pose_covariance);
-  TwistEigenSolver twist_eigensolver(twist_covariance);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance, no_tag()))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance, no_tag()))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
+  testCovariance(pose_covariance, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
 
   // Take the last two odometry messages:
   std::vector<nav_msgs::Odometry> odoms = getLastOdoms();
@@ -406,6 +357,9 @@ TEST_F(DiffDriveControllerTest, testForward)
   EXPECT_NEAR(yaw_0, yaw, std::numeric_limits<double>::epsilon());
 
   // Check new pose covariance is equal to the expected one:
+  const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
   EXPECT_TRUE(((pose_covariance_0_expected - pose_covariance_0).array().abs() < 1e-5).all())
     << "Pose covariance actual =\n" << pose_covariance_0.format(HeavyFmt)
     << "\nPose covariance expected =\n" << pose_covariance_0_expected.format(HeavyFmt);
@@ -493,37 +447,8 @@ TEST_F(DiffDriveControllerTest, testTurn)
 
   // check we have a positive definite covariance matrix
   // isCovariance = isSymmetric + isPositiveDefinite
-  const Eigen::IOFormat HeavyFmt(
-      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
-
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver(pose_covariance);
-  TwistEigenSolver twist_eigensolver(twist_covariance);
-
-  EXPECT_TRUE(pose_eigensolver.info() == Eigen::Success);
-  EXPECT_TRUE(twist_eigensolver.info() == Eigen::Success);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance, no_tag()))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance, no_tag()))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
+  testCovariance(pose_covariance, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
 
   // Take the last two odometry messages:
   std::vector<nav_msgs::Odometry> odoms = getLastOdoms();
@@ -596,6 +521,9 @@ TEST_F(DiffDriveControllerTest, testTurn)
   EXPECT_NEAR(yaw_0, yaw, ORIENTATION_TOLERANCE);
 
   // Check new pose covariance is equal to the expected one:
+  const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
   EXPECT_TRUE(((pose_covariance_0_expected - pose_covariance_0).array().abs() < 1e-5).all())
     << "Pose covariance actual =\n" << pose_covariance_0.format(HeavyFmt)
     << "\nPose covariance expected =\n" << pose_covariance_0_expected.format(HeavyFmt);

--- a/diff_drive_controller/test/gtest_common.h
+++ b/diff_drive_controller/test/gtest_common.h
@@ -1,0 +1,61 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+///////////////////////////////////////////////////////////////////////////////
+
+/// \author Enrique Fernandez
+
+#include <diff_drive_controller/covariance.h>
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+template <typename T, int N>
+void testCovariance(const Eigen::Matrix<T, N, N>& covariance,
+    const double max_condition_number = 1e3)
+{
+  using namespace diff_drive_controller;
+
+  static const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
+  typedef Eigen::SelfAdjointEigenSolver< Eigen::Matrix<T, N, N> > EigenSolver;
+
+  EigenSolver eigensolver(covariance);
+
+  EXPECT_TRUE(eigensolver.info() == Eigen::Success)
+    << "Covariance =\n" << covariance.format(HeavyFmt);
+
+  EXPECT_TRUE(isSymmetric(covariance))
+    << "Covariance =\n" << covariance.format(HeavyFmt);
+  EXPECT_TRUE(isPositiveDefinite(covariance, no_tag()))
+    << "Covariance =\n" << covariance.format(HeavyFmt) << "\n"
+    << "Eigenvalues = " << eigensolver.eigenvalues().transpose().format(HeavyFmt);
+  EXPECT_LT(conditionNumber(covariance), max_condition_number)
+    << "Covariance =\n" << covariance.format(HeavyFmt) << "\n"
+    << "Condition number = " << conditionNumber(covariance) << "\n"
+    << "Eigenvalues = " << eigensolver.eigenvalues().transpose().format(HeavyFmt);
+}

--- a/diff_drive_controller/test/odometry_test.cpp
+++ b/diff_drive_controller/test/odometry_test.cpp
@@ -87,7 +87,7 @@ static void moveOdometry(diff_drive_controller::Odometry& odometry,
     right_position += right_position_increment;
 
     odometry.updateCloseLoop(left_position, right_position,
-        left_velocity, right_velocity, t);
+        left_velocity, right_velocity, control_period);
 
     t += ros::Duration(control_period);
   }

--- a/diff_drive_controller/test/odometry_test.cpp
+++ b/diff_drive_controller/test/odometry_test.cpp
@@ -333,7 +333,7 @@ TEST(OdometryTest, testIntegrateMotionForwardFromInitial)
     J_twist * twist_covariance_1_corrected * J_twist.transpose();
 
   // Check new pose is equal to the expected one:
-  EXPECT_EQ(x_1, x);
+  EXPECT_NEAR(x_1, x, std::numeric_limits<double>::epsilon());
   EXPECT_EQ(y_1, y);
   EXPECT_EQ(yaw_1, yaw);
 
@@ -438,8 +438,8 @@ TEST(OdometryTest, testIntegrateMotionForwardFromNotInitial)
   // Note that at this point the pose is not computed using the (internal)
   // incremental pose, so we have an error greater than the double eps!
   EXPECT_NEAR(x_1, x, 1e-14);
-  EXPECT_NEAR(y_1, y, std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(yaw_1, yaw, 1e-14);
+  EXPECT_NEAR(y_1, y, 1e-14);
+  EXPECT_NEAR(yaw_1, yaw, 1e-13);
 
   // Check all pose and twist covariances are valid:
   testCovariance(pose_covariance_0, POSE_COVARIANCE_MAX_CONDITION_NUMBER);

--- a/diff_drive_controller/test/odometry_test.cpp
+++ b/diff_drive_controller/test/odometry_test.cpp
@@ -27,6 +27,8 @@
 
 /// \author Enrique Fernandez
 
+#include "gtest_common.h"
+
 #include <diff_drive_controller/odometry.h>
 #include <diff_drive_controller/covariance.h>
 #include <diff_drive_controller/rigid_body_motion.h>
@@ -118,33 +120,8 @@ TEST(OdometryTest, testInitial)
   const Eigen::IOFormat HeavyFmt(
       Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
 
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver(pose_covariance);
-  TwistEigenSolver twist_eigensolver(twist_covariance);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance, no_tag()))
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance) << "\n"
-    << "Eigenvalues = " << pose_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance, no_tag()))
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance) << "\n"
-    << "Eigenvalues = " << twist_eigensolver.eigenvalues().transpose().format(HeavyFmt);
+  testCovariance(pose_covariance, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
 
   // Check initial odometry pose and twist covariance are the small expected
   // ones:
@@ -253,65 +230,18 @@ TEST(OdometryTest, testIntegrateMotionNoMoveFromInitial)
   EXPECT_EQ(yaw_1, yaw);
 
   // Check all pose and twist covariances are valid:
+  testCovariance(pose_covariance_0, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(pose_covariance_1, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+
+  testCovariance(twist_covariance_0, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance_1, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
+
+  // Check new pose covariance is equal to the expected one:
   const Eigen::IOFormat HeavyFmt(
       Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
 
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver_0(pose_covariance_0);
-  TwistEigenSolver twist_eigensolver_0(twist_covariance_0);
-
-  PoseEigenSolver pose_eigensolver_1(pose_covariance_1);
-  TwistEigenSolver twist_eigensolver_1(twist_covariance_1);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance_0))
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance_0, no_tag()))
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance_0),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance_0) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance_0))
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance_0, no_tag()))
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance_0),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance_0) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance_1))
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance_1, no_tag()))
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance_1),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance_1) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance_1))
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance_1, no_tag()))
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance_1),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance_1) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-
-  // Check new pose covariance is equal to the expected one:
   EXPECT_TRUE(((pose_covariance_1_expected - pose_covariance_1).array().abs() < EPS_INTEGRATE_MOTION_COVARIANCE).all())
-    << "Pose covariance actual =\n" << pose_covariance_1.format(HeavyFmt)
+    << "Pose covariance actual =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
     << "\nPose covariance expected =\n" << pose_covariance_1_expected.format(HeavyFmt);
 
   // Check initial odometry pose and twist covariance are the small expected
@@ -408,63 +338,16 @@ TEST(OdometryTest, testIntegrateMotionForwardFromInitial)
   EXPECT_EQ(yaw_1, yaw);
 
   // Check all pose and twist covariances are valid:
+  testCovariance(pose_covariance_0, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(pose_covariance_1, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+
+  testCovariance(twist_covariance_0, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance_1, TWIST_COVARIANCE_MAX_CONDITION_NUMBER);
+
+  // Check new pose covariance is equal to the expected one:
   const Eigen::IOFormat HeavyFmt(
       Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
 
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver_0(pose_covariance_0);
-  TwistEigenSolver twist_eigensolver_0(twist_covariance_0);
-
-  PoseEigenSolver pose_eigensolver_1(pose_covariance_1);
-  TwistEigenSolver twist_eigensolver_1(twist_covariance_1);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance_0))
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance_0, no_tag()))
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance_0),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance_0) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance_0))
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance_0, no_tag()))
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance_0),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance_0) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance_1))
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance_1, no_tag()))
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance_1),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance_1) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance_1))
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance_1, no_tag()))
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance_1),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance_1) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-
-  // Check new pose covariance is equal to the expected one:
   EXPECT_TRUE(((pose_covariance_1_expected - pose_covariance_1).array().abs() < EPS_INTEGRATE_MOTION_COVARIANCE).all())
     << "Pose covariance actual =\n" << pose_covariance_1.format(HeavyFmt)
     << "\nPose covariance expected =\n" << pose_covariance_1_expected.format(HeavyFmt);
@@ -559,64 +442,17 @@ TEST(OdometryTest, testIntegrateMotionForwardFromNotInitial)
   EXPECT_NEAR(yaw_1, yaw, 1e-14);
 
   // Check all pose and twist covariances are valid:
-  const Eigen::IOFormat HeavyFmt(
-      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+  testCovariance(pose_covariance_0, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(pose_covariance_1, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
 
-  typedef Eigen::SelfAdjointEigenSolver<PoseCovariance> PoseEigenSolver;
-  typedef Eigen::SelfAdjointEigenSolver<TwistCovariance> TwistEigenSolver;
-
-  PoseEigenSolver pose_eigensolver_0(pose_covariance_0);
-  TwistEigenSolver twist_eigensolver_0(twist_covariance_0);
-
-  PoseEigenSolver pose_eigensolver_1(pose_covariance_1);
-  TwistEigenSolver twist_eigensolver_1(twist_covariance_1);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance_0))
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance_0, no_tag()))
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance_0),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance_0.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance_0) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance_0))
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance_0, no_tag()))
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance_0),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance_0.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance_0) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_0.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(pose_covariance_1))
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(pose_covariance_1, no_tag()))
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(pose_covariance_1),
-      POSE_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Pose covariance =\n" << pose_covariance_1.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(pose_covariance_1) << "\n"
-    << "Eigenvalues = " << pose_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-
-  EXPECT_TRUE(isSymmetric(twist_covariance_1))
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt);
-  EXPECT_TRUE(isPositiveDefinite(twist_covariance_1, no_tag()))
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
-  EXPECT_LT(conditionNumber(twist_covariance_1),
-      TWIST_COVARIANCE_MAX_CONDITION_NUMBER)
-    << "Twist covariance =\n" << twist_covariance_1.format(HeavyFmt) << "\n"
-    << "Condition number = " << conditionNumber(twist_covariance_1) << "\n"
-    << "Eigenvalues = " << twist_eigensolver_1.eigenvalues().transpose().format(HeavyFmt);
+  testCovariance(twist_covariance_0, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
+  testCovariance(twist_covariance_1, POSE_COVARIANCE_MAX_CONDITION_NUMBER);
 
   // Check the initial pose and twist state and covariance aren't zero or the
   // initial ones (since it's been moved before retrieving it):
+  const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
   EXPECT_NE(0.0, x_0);
   EXPECT_NE(0.0, y_0);
   EXPECT_NE(0.0, yaw_0);

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -26,10 +26,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 /// \author Bence Magyar
+/// \author Enrique Fernandez
 
 #include <cmath>
 
-#include <gtest/gtest.h>
+#include <limits>
 
 #include <ros/ros.h>
 
@@ -45,6 +46,8 @@
 #include <Eigen/Dense>
 
 #include <std_srvs/Empty.h>
+
+#include "gtest_common.h"
 
 // Floating-point value comparison threshold
 const double EPS = 0.01;


### PR DESCRIPTION
This PR is on top of #24 

This fixes an issue with the default values that get assigned to the static param that are also defined as dynamic params:
- When one of this params is not defined in the param server, the default value is taken from the `cfg` file, not the default used in the constructor.
- When one of this params is on the param server, dynamic reconfigure takes it.
- This PR changes the default values in the constructor with the defaults from the `cfg` file,
- and updates the defaults of `cfg` to better defaults

This PR also fixes some minor issues (in a separate commit).

@afakihcpr @mikepurvis 
