### PR TITLE
Create linear/quadratic meas cov model classes

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -49,12 +49,16 @@ include_directories(
   include ${catkin_INCLUDE_DIRS}
   include ${Boost_INCLUDE_DIRS}
   include ${EIGEN_INCLUDE_DIRS}
-  include ${sophus_INCLUDE_DIRS}
   include ${CERES_INCLUDE_DIRS})
 
 roslint_cpp()
 
-add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
+add_library(${PROJECT_NAME}
+  src/diff_drive_controller.cpp
+  src/linear_meas_covariance_model.cpp
+  src/quadratic_meas_covariance_model.cpp
+  src/odometry.cpp
+  src/speed_limiter.cpp)
 # Note that the entry for ${Ceres_LIBRARIES} was removed as we only used headers from that package
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)

--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -13,8 +13,10 @@ gen.add("wheel_separation_multiplier",  double_t, 0, "Wheel separation multiplie
 gen.add("left_wheel_radius_multiplier",  double_t, 0, "Left wheel radius multiplier.", 1.0, 0.5, 1.5)
 gen.add("right_wheel_radius_multiplier",  double_t, 0, "Right wheel radius multiplier.", 1.0, 0.5, 1.5)
 
-gen.add("k_l",  double_t, 0, "Covariance model k_l multiplier.", 1.0, 0.0, 10.0)
-gen.add("k_r",  double_t, 0, "Covariance model k_r multiplier.", 1.0, 0.0, 10.0)
+gen.add("k_l",  double_t, 0, "Covariance model k_l multiplier.", 0.01, 0.0, 10.0)
+gen.add("k_r",  double_t, 0, "Covariance model k_r multiplier.", 0.01, 0.0, 10.0)
+
+gen.add("wheel_resolution",  double_t, 0, "Wheel position resolution [rad] (used in the Covariance model).", 0.0, 0.0, 10.0)
 
 gen.add("publish_cmd_vel_limited", bool_t, 0, "Publish limited velocity command.", False)
 gen.add("publish_state", bool_t, 0, "Publish joint trajectory controller state.", False)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -205,6 +205,8 @@ namespace diff_drive_controller
       double k_l;
       double k_r;
 
+      double wheel_resolution;
+
       bool publish_state;
       bool publish_cmd_vel_limited;
 
@@ -216,8 +218,9 @@ namespace diff_drive_controller
         , wheel_separation_multiplier(1.0)
         , left_wheel_radius_multiplier(1.0)
         , right_wheel_radius_multiplier(1.0)
-        , k_l(1.0)
-        , k_r(1.0)
+        , k_l(0.01)
+        , k_r(0.01)
+        , wheel_resolution(0.0)
         , publish_state(false)
         , publish_cmd_vel_limited(false)
         , control_frequency_desired(0.0)
@@ -240,6 +243,8 @@ namespace diff_drive_controller
     /// Measurement Covariance Model multipliers:
     double k_l_;
     double k_r_;
+
+    double wheel_resolution_;  // [rad]
 
     /// Timeout to consider cmd_vel commands old:
     double cmd_vel_timeout_;

--- a/diff_drive_controller/include/diff_drive_controller/linear_meas_covariance_model.h
+++ b/diff_drive_controller/include/diff_drive_controller/linear_meas_covariance_model.h
@@ -1,0 +1,93 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#ifndef LINEAR_MEAS_COVARIANCE_MODEL_H_
+#define LINEAR_MEAS_COVARIANCE_MODEL_H_
+
+#include <diff_drive_controller/meas_covariance_model.h>
+
+namespace diff_drive_controller
+{
+
+  /**
+   * \brief Linear Meas(urement) Covariance Model
+   *
+   * The odometry covariance is computed according with the model presented in:
+   *
+   * [Siegwart, 2004]:
+   *   Roland Siegwart, Illah R. Nourbakhsh
+   *   Introduction to Autonomous Mobile Robots
+   *   1st Edition, 2004
+   *
+   * Section:
+   *   5.2.4 'An error model for odometric position estimation' (pp. 186-191)
+   *
+   * Although the twist covariance doesn't appear explicitly, the implementation
+   * here is based on the same covariance model used for the pose covariance.
+   *
+   * The model also includes the wheel resolution, as a constant additive
+   * diagonal covariance, that can be easily disabled by using a zero
+   * (ideal/perfect) wheel resolution.
+   */
+  class LinearMeasCovarianceModel : public MeasCovarianceModel
+  {
+    public:
+      /**
+       * \brief Constructor
+       * \param[in] wheel_resolution Wheel resolution [rad]
+       */
+      LinearMeasCovarianceModel(const double wheel_resolution = 0.0);
+
+      /**
+       * \brief Destructor
+       */
+      virtual ~LinearMeasCovarianceModel()
+      {}
+
+      /**
+       * \brief Integrates w/o computing the jacobians
+       * \param [in] dp_l Left wheel position increment [rad]
+       * \param [in] dp_r Right wheel position increment [rad]
+       * \return Meas(urement) covariance
+       */
+      const MeasCovariance& compute(const double dp_l, const double dp_r);
+  };
+
+}  // namespace diff_drive_controller
+
+#endif /* LINEAR_MEAS_COVARIANCE_MODEL_H_ */

--- a/diff_drive_controller/include/diff_drive_controller/meas_covariance_model.h
+++ b/diff_drive_controller/include/diff_drive_controller/meas_covariance_model.h
@@ -1,0 +1,143 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#ifndef MEAS_COVARIANCE_MODEL_H_
+#define MEAS_COVARIANCE_MODEL_H_
+
+#include <Eigen/Core>
+
+namespace diff_drive_controller
+{
+
+  /**
+   * \brief Meas(urement) Covariance Model
+   */
+  class MeasCovarianceModel
+  {
+    public:
+      /// Meas(urement) covariance type:
+      typedef Eigen::Matrix2d MeasCovariance;
+
+      /**
+       * \brief Constructor
+       * \param[in] wheel_resolution Wheel resolution [rad]
+       */
+      MeasCovarianceModel(const double wheel_resolution = 0.0)
+        : wheel_resolution_(wheel_resolution)
+      {}
+
+      virtual ~MeasCovarianceModel()
+      {}
+
+      /**
+       * \brief Integrates w/o computing the jacobians
+       * \param [in] dp_l Left wheel position increment [rad]
+       * \param [in] dp_r Right wheel position increment [rad]
+       * \return Meas(urement) covariance
+       */
+      virtual const MeasCovariance& compute(const double dp_l, const double dp_r) = 0;
+
+      /**
+       * \brief Left wheel covariance gain getter
+       * \return Left wheel covariance gain
+       */
+      double getKl() const
+      {
+        return k_l_;
+      }
+
+      /**
+       * \brief Right wheel covariance gain getter
+       * \return Right wheel covariance gain
+       */
+      double getKr() const
+      {
+        return k_r_;
+      }
+
+      /**
+       * \brief Wheel resolution getter
+       * \return Wheel resolution [rad]
+       */
+      double getWheelResolution() const
+      {
+        return wheel_resolution_;
+      }
+
+      /**
+       * \brief Left wheel covariance gain setter
+       * \param[in] k_l Left wheel covariance gain
+       */
+      void setKl(const double k_l)
+      {
+        k_l_ = k_l;
+      }
+
+      /**
+       * \brief Right wheel covariance gain setter
+       * \param[in] k_r Right wheel covariance gain
+       */
+      void setKr(const double k_r)
+      {
+        k_r_ = k_r;
+      }
+
+      /**
+       * \brief Wheel resolution setter
+       * \param[in] wheel_resolution Wheel resolution [rad]
+       */
+      void setWheelResolution(const double wheel_resolution)
+      {
+        wheel_resolution_ = wheel_resolution;
+      }
+
+    protected:
+      /// Meas(urement) covariance:
+      MeasCovariance meas_covariance_;
+
+      /// Meas(urement) Covariance Model gains:
+      double k_l_;
+      double k_r_;
+
+      /// Wheel resolution [rad]:
+      double wheel_resolution_;
+  };
+
+}  // namespace diff_drive_controller
+
+#endif /* MEAS_COVARIANCE_MODEL_H_ */

--- a/diff_drive_controller/include/diff_drive_controller/quadratic_meas_covariance_model.h
+++ b/diff_drive_controller/include/diff_drive_controller/quadratic_meas_covariance_model.h
@@ -1,0 +1,114 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#ifndef QUADRATIC_MEAS_COVARIANCE_MODEL_H_
+#define QUADRATIC_MEAS_COVARIANCE_MODEL_H_
+
+#include <diff_drive_controller/meas_covariance_model.h>
+
+namespace diff_drive_controller
+{
+
+  /**
+   * \brief Quadratic Meas(urement) Covariance Model
+   *
+   * The odometry covariance is computed using a similar model to the one
+   * presented in:
+   *
+   * [Siegwart, 2004]:
+   *   Roland Siegwart, Illah R. Nourbakhsh
+   *   Introduction to Autonomous Mobile Robots
+   *   1st Edition, 2004
+   *
+   * Section:
+   *   5.2.4 'An error model for odometric position estimation' (pp. 186-191)
+   *
+   * Although the twist covariance doesn't appear explicitly, the implementation
+   * here is based on the same covariance model used for the pose covariance.
+   *
+   * Instead of using the std::abs of the wheel position increment dp, this
+   * model uses the squared (quadratic) value of dp, so the proportional term
+   * (multiplied by k_*_) does NOT depend on the control period dt (see
+   * explanation below).
+   *
+   * This is important because it makes the covariance model independent of
+   * the control period dt. Since dp = v * dt, the variance actually gives:
+   *
+   *   dp^2 = (v * dt)^2 = v^2 * dt^2
+   *
+   * where dt^2 gets cancelled when the covariance propagation for the twist
+   * is applied, i.e. the 1/dt jacobians pre- and post-multiply this
+   * covariance model, so the control perdio dt cancels out:
+   *
+   *   (1/dt) * dt^2 * (1/dt) = dt^2 / dt^2 = 1
+   *
+   * The model also includes the wheel resolution, as a constant additive
+   * diagonal covariance, that can be easily disabled by using a zero
+   * (ideal/perfect) wheel resolution.
+   *
+   * If the wheel resolution (DC offset) term is used, the covariance model
+   * would again vary with the control period dt because the wheel
+   * resolution is constant and does NOT include/depend on dt.
+   */
+  class QuadraticMeasCovarianceModel : public MeasCovarianceModel
+  {
+    public:
+      /**
+       * \brief Constructor
+       * \param[in] wheel_resolution Wheel resolution [rad]
+       */
+      QuadraticMeasCovarianceModel(const double wheel_resolution = 0.0);
+
+      /**
+       * \brief Destructor
+       */
+      virtual ~QuadraticMeasCovarianceModel()
+      {}
+
+      /**
+       * \brief Integrates w/o computing the jacobians
+       * \param [in] dp_l Left wheel position increment [rad]
+       * \param [in] dp_r Right wheel position increment [rad]
+       * \return Meas(urement) covariance
+       */
+      const MeasCovariance& compute(const double dp_l, const double dp_r);
+  };
+
+}  // namespace diff_drive_controller
+
+#endif /* QUADRATIC_MEAS_COVARIANCE_MODEL_H_ */

--- a/diff_drive_controller/src/linear_meas_covariance_model.cpp
+++ b/diff_drive_controller/src/linear_meas_covariance_model.cpp
@@ -1,0 +1,72 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#include <diff_drive_controller/linear_meas_covariance_model.h>
+
+namespace diff_drive_controller
+{
+
+LinearMeasCovarianceModel::LinearMeasCovarianceModel(
+    const double wheel_resolution)
+  : MeasCovarianceModel(wheel_resolution)
+{
+  meas_covariance_.setZero();
+}
+
+const MeasCovarianceModel::MeasCovariance&
+LinearMeasCovarianceModel::compute(const double dp_l, const double dp_r)
+{
+  /// Measurement (wheel position increment) covaraince model, proportional
+  /// to the wheel position increment abs(olute) value for each wheel:
+  const double dp_var_l = k_l_ * std::abs(dp_l);
+  const double dp_var_r = k_r_ * std::abs(dp_r);
+
+  /// Wheel resolution covariance, which is like a DC offset equal to half of
+  /// the resolution, which is the theoretical average error:
+  const double dp_var_avg = 0.5 * wheel_resolution_;
+
+  /// @todo This can be extended to support lateral slippage
+  /// k_s_ * [see/find Olson notes]
+
+  /// Set covariance matrix (diagonal):
+  meas_covariance_.diagonal() << dp_var_l + dp_var_avg,
+                                 dp_var_r + dp_var_avg;
+}
+
+}  // namespace diff_drive_controller
+

--- a/diff_drive_controller/src/quadratic_meas_covariance_model.cpp
+++ b/diff_drive_controller/src/quadratic_meas_covariance_model.cpp
@@ -1,0 +1,76 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#include <diff_drive_controller/quadratic_meas_covariance_model.h>
+
+namespace diff_drive_controller
+{
+
+QuadraticMeasCovarianceModel::QuadraticMeasCovarianceModel(
+    const double wheel_resolution)
+  : MeasCovarianceModel(wheel_resolution)
+{
+  meas_covariance_.setZero();
+}
+
+const MeasCovarianceModel::MeasCovariance&
+QuadraticMeasCovarianceModel::compute(const double dp_l, const double dp_r)
+{
+  /// Measurement (wheel position increment) covaraince model, proportional
+  /// to the wheel position increment squared (quadratic) for each wheel:
+  const double dp_std_l = k_l_ * dp_l;
+  const double dp_std_r = k_r_ * dp_r;
+
+  const double dp_var_l = dp_std_l * dp_std_l;
+  const double dp_var_r = dp_std_r * dp_std_r;
+
+  /// Wheel resolution covariance, which is like a DC offset equal to half of
+  /// the resolution, which is the theoretical average error:
+  const double dp_std_avg = 0.5 * wheel_resolution_;
+  const double dp_var_avg = dp_std_avg * dp_std_avg;
+
+  /// @todo This can be extended to support lateral slippage
+  /// k_s_ * [see/find Olson notes]
+
+  /// Set covariance matrix (diagonal):
+  meas_covariance_.diagonal() << dp_var_l + dp_var_avg,
+                                 dp_var_r + dp_var_avg;
+}
+
+}  // namespace diff_drive_controller
+

--- a/diff_drive_controller/test/odometry_test.cpp
+++ b/diff_drive_controller/test/odometry_test.cpp
@@ -46,6 +46,10 @@ const double RIGHT_WHEEL_RADIUS = LEFT_WHEEL_RADIUS;
 
 const double K_L = 0.01;
 const double K_R = K_L;
+// Instead of a more realistic wheel resolution like the one below, we can also
+// use 0.0 to avoid minor errors (see EPS_ constants below), but even with 0.0
+// we have them:
+const double WHEEL_RESOLUTION = 2.0 * M_PI / (25.0 * 1024);
 
 const size_t CONTROL_STEPS = 100;
 const double CONTROL_PERIOD = 0.02;  // [s]
@@ -62,7 +66,7 @@ static void setupOdometry(diff_drive_controller::Odometry& odometry)
   odometry.setWheelParams(WHEEL_SEPARATION,
       LEFT_WHEEL_RADIUS, RIGHT_WHEEL_RADIUS);
 
-  odometry.setMeasCovarianceParams(K_L, K_R);
+  odometry.setMeasCovarianceParams(K_L, K_R, WHEEL_RESOLUTION);
 }
 
 static void moveOdometry(diff_drive_controller::Odometry& odometry,
@@ -167,6 +171,10 @@ TEST(OdometryTest, testIntegrateMotionNoMoveFromInitial)
 
   diff_drive_controller::Odometry odometry(1);
   setupOdometry(odometry);
+
+  // Set wheel resolution to 0.0, because when it's != 0.0 the covariance
+  // always grows a little on every single step, even if the robot doesn't move:
+  odometry.setMeasCovarianceParams(K_L, K_R, 0.0);
 
   // Save initial/current pose and twist state and covariance:
   const double x_0   = odometry.getX();


### PR DESCRIPTION
This creates #24 on top of `indigo-devel`.

Now I provide the linear and quadratic model, so the user can select them (in this PR only at compilation time, changing the code). Both models also support a wheel resolution param, which is 0.0 by
default.

In future PRs I'd allow to change from one model to the other using a static (or dynamic) param, and also for the integration method.

@afakihcpr @ayrton04 @servos 
