### PR TITLE
Add Analytic Jacobians

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -87,6 +87,9 @@ if (CATKIN_ENABLE_TESTING)
     ${catkin_INCLUDE_DIRS}
     ${EIGEN_INCLUDE_DIRS})
 
+  catkin_add_gtest(integrate_functor_test test/integrate_functor_test.cpp)
+  target_link_libraries(integrate_functor_test ${PROJECT_NAME})
+
   catkin_add_gtest(odometry_test test/odometry_test.cpp)
   target_link_libraries(odometry_test ${PROJECT_NAME})
 

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -55,8 +55,10 @@ roslint_cpp()
 
 add_library(${PROJECT_NAME}
   src/diff_drive_controller.cpp
+  src/meas_covariance_model.cpp
   src/linear_meas_covariance_model.cpp
   src/quadratic_meas_covariance_model.cpp
+  src/integrate_function.cpp
   src/odometry.cpp
   src/speed_limiter.cpp)
 # Note that the entry for ${Ceres_LIBRARIES} was removed as we only used headers from that package

--- a/diff_drive_controller/include/diff_drive_controller/analytic_integrate_function.h
+++ b/diff_drive_controller/include/diff_drive_controller/analytic_integrate_function.h
@@ -36,18 +36,19 @@
  * Author: Enrique Fernández
  */
 
-#ifndef INTEGRATE_FUNCTION_H_
-#define INTEGRATE_FUNCTION_H_
+#ifndef ANALYTIC_INTEGRATE_FUNCTION_H_
+#define ANALYTIC_INTEGRATE_FUNCTION_H_
 
-#include <Eigen/Core>
+#include <diff_drive_controller/integrate_function.h>
 
 namespace diff_drive_controller
 {
 
   /**
-   * \brief Integrate function
+   * \brief Integrate function, which computes jacobians analytically
    */
-  class IntegrateFunction
+  template <template <typename> class IntegrateFunctor, typename Functor>
+  class AnalyticIntegrateFunction : public IntegrateFunction
   {
     public:
       /// Pose and measurement jacobian types:
@@ -56,11 +57,10 @@ namespace diff_drive_controller
 
       /**
        * \brief Constructor
+       * \param [in] functor Integrate functor
        */
-      IntegrateFunction()
-      {}
-
-      virtual ~IntegrateFunction()
+      AnalyticIntegrateFunction(IntegrateFunctor<Functor>* functor)
+        : functor_(functor)
       {}
 
       /**
@@ -72,7 +72,10 @@ namespace diff_drive_controller
        * \param[in] v_r Right wheel velocity (displacement)
        */
       virtual void operator()(double& x, double& y, double& Y,
-          const double& v_l, const double& v_r) const = 0;
+          const double& v_l, const double& v_r) const
+      {
+        (*functor_)(x, y, Y, v_l, v_r);
+      }
 
       /**
        * \brief Integrates and computes the jacobians
@@ -86,7 +89,11 @@ namespace diff_drive_controller
        */
       virtual void operator()(double& x, double& y, double& Y,
           const double& v_l, const double& v_r,
-          PoseJacobian& J_pose, MeasJacobian& J_meas) const = 0;
+          PoseJacobian& J_pose, MeasJacobian& J_meas) const
+      {
+        /// Integrate and compute the partial derivatives:
+        (*functor_)(x, y, Y, v_l, v_r, J_pose, J_meas);
+      }
 
       /**
        * \brief Sets the wheel parameters: radius and separation
@@ -96,10 +103,17 @@ namespace diff_drive_controller
        * \param[in] right_wheel_radius Right wheel radius [m]
        */
       virtual void setWheelParams(const double wheel_separation,
-            const double left_wheel_radius,
-            const double right_wheel_radius) = 0;
+          const double left_wheel_radius, const double right_wheel_radius)
+      {
+        functor_->setWheelParams(wheel_separation,
+            left_wheel_radius, right_wheel_radius);
+      }
+
+    private:
+      /// Integrate functor:
+      boost::shared_ptr< IntegrateFunctor<Functor> > functor_;
   };
 
 }  // namespace diff_drive_controller
 
-#endif /* INTEGRATE_FUNCTION_H_ */
+#endif /* ANALYTIC_INTEGRATE_FUNCTION_H_ */

--- a/diff_drive_controller/include/diff_drive_controller/analytic_integrate_function.h
+++ b/diff_drive_controller/include/diff_drive_controller/analytic_integrate_function.h
@@ -57,10 +57,9 @@ namespace diff_drive_controller
 
       /**
        * \brief Constructor
-       * \param [in] functor Integrate functor
        */
-      AnalyticIntegrateFunction(IntegrateFunctor<Functor>* functor)
-        : functor_(functor)
+      AnalyticIntegrateFunction()
+        : functor_()
       {}
 
       /**
@@ -74,7 +73,7 @@ namespace diff_drive_controller
       virtual void operator()(double& x, double& y, double& Y,
           const double& v_l, const double& v_r) const
       {
-        (*functor_)(x, y, Y, v_l, v_r);
+        functor_(x, y, Y, v_l, v_r);
       }
 
       /**
@@ -92,7 +91,7 @@ namespace diff_drive_controller
           PoseJacobian& J_pose, MeasJacobian& J_meas) const
       {
         /// Integrate and compute the partial derivatives:
-        (*functor_)(x, y, Y, v_l, v_r, J_pose, J_meas);
+        functor_(x, y, Y, v_l, v_r, J_pose, J_meas);
       }
 
       /**
@@ -105,13 +104,13 @@ namespace diff_drive_controller
       virtual void setWheelParams(const double wheel_separation,
           const double left_wheel_radius, const double right_wheel_radius)
       {
-        functor_->setWheelParams(wheel_separation,
+        functor_.setWheelParams(wheel_separation,
             left_wheel_radius, right_wheel_radius);
       }
 
     private:
       /// Integrate functor:
-      boost::shared_ptr< IntegrateFunctor<Functor> > functor_;
+      IntegrateFunctor<Functor> functor_;
   };
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/include/diff_drive_controller/autodiff_integrate_function.h
+++ b/diff_drive_controller/include/diff_drive_controller/autodiff_integrate_function.h
@@ -60,10 +60,9 @@ namespace diff_drive_controller
 
       /**
        * \brief Constructor
-       * \param[in] functor Integrate functor
        */
-      AutoDiffIntegrateFunction(IntegrateFunctor<Functor>* functor)
-        : functor_(functor)
+      AutoDiffIntegrateFunction()
+        : functor_()
       {}
 
       /**
@@ -77,7 +76,7 @@ namespace diff_drive_controller
       virtual void operator()(double& x, double& y, double& Y,
           const double& v_l, const double& v_r) const
       {
-        (*functor_)(x, y, Y, v_l, v_r);
+        functor_(x, y, Y, v_l, v_r);
       }
 
       /**
@@ -104,7 +103,7 @@ namespace diff_drive_controller
         ceres::Jet<double, 5> jet_v_r(v_r, 4);
 
         /// Integrate and compute the partial derivatives:
-        (*functor_)(jet_x, jet_y, jet_Y, jet_v_l, jet_v_r);
+        functor_(jet_x, jet_y, jet_Y, jet_v_l, jet_v_r);
 
         /// Retrieve solution:
         x = jet_x.a;
@@ -132,13 +131,13 @@ namespace diff_drive_controller
       virtual void setWheelParams(const double wheel_separation,
           const double left_wheel_radius, const double right_wheel_radius)
       {
-        functor_->setWheelParams(wheel_separation,
+        functor_.setWheelParams(wheel_separation,
             left_wheel_radius, right_wheel_radius);
       }
 
     private:
       /// Integrate functor:
-      boost::shared_ptr< IntegrateFunctor<Functor> > functor_;
+      IntegrateFunctor<Functor> functor_;
   };
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/include/diff_drive_controller/autodiff_integrate_function.h
+++ b/diff_drive_controller/include/diff_drive_controller/autodiff_integrate_function.h
@@ -60,7 +60,7 @@ namespace diff_drive_controller
 
       /**
        * \brief Constructor
-       * \param [in] functor Integrate functor
+       * \param[in] functor Integrate functor
        */
       AutoDiffIntegrateFunction(IntegrateFunctor<Functor>* functor)
         : functor_(functor)
@@ -68,11 +68,11 @@ namespace diff_drive_controller
 
       /**
        * \brief Integrates w/o computing the jacobians
-       * \param [in, out] x Pose x component
-       * \param [in, out] y Pose y component
-       * \param [in, out] Y Pose yaw component
-       * \param [in] v_l Left  wheel velocity (displacement)
-       * \param [in] v_r Right wheel velocity (displacement)
+       * \param[in, out] x Pose x component
+       * \param[in, out] y Pose y component
+       * \param[in, out] Y Pose yaw component
+       * \param[in] v_l Left  wheel velocity (displacement)
+       * \param[in] v_r Right wheel velocity (displacement)
        */
       virtual void operator()(double& x, double& y, double& Y,
           const double& v_l, const double& v_r) const
@@ -82,13 +82,13 @@ namespace diff_drive_controller
 
       /**
        * \brief Integrates and computes the jacobians
-       * \param [in, out] x Pose x component
-       * \param [in, out] y Pose y component
-       * \param [in, out] Y Pose yaw component
-       * \param [in] v_l Left  wheel velocity (displacement)
-       * \param [in] v_r Right wheel velocity (displacement)
-       * \param [out] J_pose Jacobian (3x3) wrt the pose (x, y, Y)
-       * \param [out] J_meas Jacobian (3x2) wrt the measurement (v_l, v_r)
+       * \param[in, out] x Pose x component
+       * \param[in, out] y Pose y component
+       * \param[in, out] Y Pose yaw component
+       * \param[in] v_l Left  wheel velocity (displacement)
+       * \param[in] v_r Right wheel velocity (displacement)
+       * \param[out] J_pose Jacobian (3x3) wrt the pose (x, y, Y)
+       * \param[out] J_meas Jacobian (3x2) wrt the measurement (v_l, v_r)
        */
       virtual void operator()(double& x, double& y, double& Y,
           const double& v_l, const double& v_r,
@@ -124,12 +124,13 @@ namespace diff_drive_controller
 
       /**
        * \brief Sets the wheel parameters: radius and separation
-       * \param wheel_separation   Seperation between left and right wheels [m]
-       * \param left_wheel_radius  Left  wheel radius [m]
-       * \param right_wheel_radius Right wheel radius [m]
+       * \param[in] wheel_separation   Seperation between
+       *                               left and right wheels [m]
+       * \param[in] left_wheel_radius  Left  wheel radius [m]
+       * \param[in] right_wheel_radius Right wheel radius [m]
        */
-      virtual void setWheelParams(double wheel_separation,
-          double left_wheel_radius, double right_wheel_radius)
+      virtual void setWheelParams(const double wheel_separation,
+          const double left_wheel_radius, const double right_wheel_radius)
       {
         functor_->setWheelParams(wheel_separation,
             left_wheel_radius, right_wheel_radius);

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -296,6 +296,13 @@ namespace diff_drive_controller
     double control_frequency_desired_;
     double control_period_desired_;
 
+    /// Meas(urement) Covariance Model, which can be: "linear", "quadratic":
+    std::string meas_covariance_model_;
+
+    /// Integrate method, which can be: "euler", "rungekutta2", "exact"
+    /// and differentiation scheme, which can be: "analytic", "autodiff"
+    std::string integrate_method_;
+    std::string integrate_differentiation_;
   private:
     /**
      * \brief Brakes the wheels, i.e. sets the velocity to 0

--- a/diff_drive_controller/include/diff_drive_controller/direct_kinematics_integrate_functor.h
+++ b/diff_drive_controller/include/diff_drive_controller/direct_kinematics_integrate_functor.h
@@ -42,7 +42,6 @@
 #include <diff_drive_controller/integrate_function.h>
 
 #include <boost/type_traits.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/static_assert.hpp>
 
 namespace diff_drive_controller
@@ -52,8 +51,8 @@ namespace diff_drive_controller
   template <typename Functor>
   struct DirectKinematicsIntegrateFunctor
   {
-    DirectKinematicsIntegrateFunctor(Functor* functor)
-      : functor_(functor)
+    DirectKinematicsIntegrateFunctor()
+      : functor_()
       , wheel_separation_(0.0)
       , left_wheel_radius_(0.0)
       , right_wheel_radius_(0.0)
@@ -87,7 +86,7 @@ namespace diff_drive_controller
       const T w = (vr - vl) / T(wheel_separation_);
 
       /// Integrate:
-      (*functor_)(x, y, yaw, v, w);
+      functor_(x, y, yaw, v, w);
     }
 
     /**
@@ -125,7 +124,7 @@ namespace diff_drive_controller
               -left_wheel_radius_ * b_inv, right_wheel_radius_ * b_inv;
 
       /// Integrate:
-      (*functor_)(x, y, yaw, v, w, J_pose, J_meas);
+      functor_(x, y, yaw, v, w, J_pose, J_meas);
 
       /// Jacobian wrt wheel velocities (v_l, v_r), applying the chain rule:
       J_meas *= J_dk;
@@ -148,7 +147,7 @@ namespace diff_drive_controller
 
   private:
     /// Integrate functor:
-    boost::shared_ptr<Functor> functor_;
+    Functor functor_;
 
     /// Wheel parameters:
     double wheel_separation_;

--- a/diff_drive_controller/include/diff_drive_controller/direct_kinematics_integrate_functor.h
+++ b/diff_drive_controller/include/diff_drive_controller/direct_kinematics_integrate_functor.h
@@ -39,6 +39,8 @@
 #ifndef DIRECT_KINEMATICS_INTEGRATE_FUNCTOR_H_
 #define DIRECT_KINEMATICS_INTEGRATE_FUNCTOR_H_
 
+#include <diff_drive_controller/integrate_function.h>
+
 #include <boost/type_traits.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/static_assert.hpp>
@@ -60,15 +62,16 @@ namespace diff_drive_controller
     /**
      * \brief Integrates the pose (x, y, yaw) given the wheel velocities
      * (v_l, v_r)
-     * \param [in, out] x   Pose x   component
-     * \param [in, out] y   Pose y   component
-     * \param [in, out] yaw Pose yaw component
-     * \param [in] v_l Left  wheel velocity [rad]
-     *                 (angular  displacement, i.e. rad/s * dt) computed by encoders
-     * \param [in] v_r Right wheel velocity [rad]
+     * \param[in, out] x   Pose x   component
+     * \param[in, out] y   Pose y   component
+     * \param[in, out] yaw Pose yaw component
+     * \param[in] v_l Left  wheel velocity [rad]
+     *                (angular  displacement, i.e. rad/s * dt) computed by encoders
+     * \param[in] v_r Right wheel velocity [rad]
      *                 (angular  displacement, i.e. rad/s * dt) computed by encoders
      */
     template <typename T>
+    // @todo rename v_l, v_r to dp_l, dp_r (here and in other files)
     void operator()(T& x, T& y, T& yaw, const T& v_l, const T& v_r) const
     {
       BOOST_STATIC_ASSERT_MSG(
@@ -88,13 +91,55 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief Sets the wheel parameters: radius and separation
-     * \param wheel_separation   Seperation between left and right wheels [m]
-     * \param left_wheel_radius  Left  wheel radius [m]
-     * \param right_wheel_radius Right wheel radius [m]
+     * \brief Integrates the pose (x, y, yaw) given the wheel velocities
+     * (v_l, v_r)
+     * \param[in, out] x   Pose x   component
+     * \param[in, out] y   Pose y   component
+     * \param[in, out] yaw Pose yaw component
+     * \param[in] v_l Left  wheel velocity [rad]
+     *                (angular  displacement, i.e. rad/s * dt) computed by encoders
+     * \param[in] v_r Right wheel velocity [rad]
+     *                (angular  displacement, i.e. rad/s * dt) computed by encoders
+     * \param[out] J_pose Jacobian wrt the pose (x, y, yaw)
+     * \param[out] J_meas Jacobian wrt the meas(urement) wheel velocities
+     *                    (v_l, v_r)
      */
-    void setWheelParams(double wheel_separation,
-        double left_wheel_radius, double right_wheel_radius)
+    void operator()(double& x, double& y, double& yaw,
+        const double& v_l, const double& v_r,
+        IntegrateFunction::PoseJacobian& J_pose,
+        IntegrateFunction::MeasJacobian& J_meas) const
+    {
+      /// Compute direct kinematics, i.e. obtain linear and angular velocity
+      /// from wheel velocities:
+      const double vl = v_l * left_wheel_radius_;
+      const double vr = v_r * right_wheel_radius_;
+
+      const double b_inv = 1.0 / wheel_separation_;
+
+      const double v = (vr + vl) * 0.5;
+      const double w = (vr - vl) * b_inv;
+
+      /// Jacobian of direct kinematics:
+      Eigen::Matrix2d J_dk;
+      J_dk << 0.5 * left_wheel_radius_, 0.5 * right_wheel_radius_,
+              -left_wheel_radius_ * b_inv, right_wheel_radius_ * b_inv;
+
+      /// Integrate:
+      (*functor_)(x, y, yaw, v, w, J_pose, J_meas);
+
+      /// Jacobian wrt wheel velocities (v_l, v_r), applying the chain rule:
+      J_meas *= J_dk;
+    }
+
+    /**
+     * \brief Sets the wheel parameters: radius and separation
+     * \param[in] wheel_separation   Seperation between
+     *                               left and right wheels [m]
+     * \param[in] left_wheel_radius  Left  wheel radius [m]
+     * \param[in] right_wheel_radius Right wheel radius [m]
+     */
+    void setWheelParams(const double wheel_separation,
+        const double left_wheel_radius, const double right_wheel_radius)
     {
       wheel_separation_   = wheel_separation;
       left_wheel_radius_  = left_wheel_radius;
@@ -110,7 +155,6 @@ namespace diff_drive_controller
     double left_wheel_radius_;
     double right_wheel_radius_;
   };
-
 
 } // namespace diff_drive_controller
 

--- a/diff_drive_controller/include/diff_drive_controller/euler_integrate_functor.h
+++ b/diff_drive_controller/include/diff_drive_controller/euler_integrate_functor.h
@@ -36,20 +36,25 @@
  * Author: Enrique Fernández
  */
 
-#ifndef EXACT_INTEGRATE_FUNCTOR_H_
-#define EXACT_INTEGRATE_FUNCTOR_H_
+#ifndef EULER_INTEGRATE_FUNCTOR_H_
+#define EULER_INTEGRATE_FUNCTOR_H_
 
-#include <diff_drive_controller/runge_kutta_2_integrate_functor.h>
+#include <diff_drive_controller/integrate_function.h>
+
+#include <boost/type_traits.hpp>
+#include <boost/static_assert.hpp>
+
+#include <cmath>
 
 namespace diff_drive_controller
 {
 
-  /// Exact integration:
-  struct ExactIntegrateFunctor
+  /// Euler integration:
+  struct EulerIntegrateFunctor
   {
     /**
      * \brief Integrates the pose (x, y, yaw) given the velocities (v, w) using
-     * exact (arc) method
+     * Euler
      * \param[in, out] x   Pose x   component
      * \param[in, out] y   Pose y   component
      * \param[in, out] yaw Pose yaw component
@@ -65,24 +70,14 @@ namespace diff_drive_controller
           !boost::is_pod<T>::value || boost::is_floating_point<T>::value,
           "The pose components must be specified as float values.");
 
-      if (abs(w) < 1e-9)
-      {
-        RungeKutta2IntegrateFunctor()(x, y, yaw, v, w);
-      }
-      else
-      {
-        /// Exact integration (should solve problems when angular is zero):
-        const T yaw_old = yaw;
-        const T r = v / w;
-        yaw += w;
-        x   +=  r * (sin(yaw) - sin(yaw_old));
-        y   += -r * (cos(yaw) - cos(yaw_old));
-      }
+      x   += v * cos(yaw);
+      y   += v * sin(yaw);
+      yaw += w;
     }
 
     /**
      * \brief Integrates the pose (x, y, yaw) given the velocities (v, w) using
-     * exact (arc) method
+     * Euler
      * \param[in, out] x   Pose x   component
      * \param[in, out] y   Pose y   component
      * \param[in, out] yaw Pose yaw component
@@ -98,44 +93,23 @@ namespace diff_drive_controller
         IntegrateFunction::PoseJacobian& J_pose,
         IntegrateFunction::MeasJacobian& J_meas) const
     {
-      if (std::abs(w) < 1e-9)
-      {
-        RungeKutta2IntegrateFunctor()(x, y, yaw, v, w, J_pose, J_meas);
-      }
-      else
-      {
-        const double w_inv = 1.0 / w;
+      const double cos_yaw = std::cos(yaw);
+      const double sin_yaw = std::sin(yaw);
 
-        const double r = v * w_inv;
+      x   += v * cos_yaw;
+      y   += v * sin_yaw;
+      yaw += w;
 
-        const double cos_yaw_old = std::cos(yaw);
-        const double sin_yaw_old = std::sin(yaw);
+      J_pose << 1.0, 0.0, -v * sin_yaw,
+                0.0, 1.0,  v * cos_yaw,
+                0.0, 0.0, 1.0;
 
-        yaw += w;
-
-        const double cos_yaw = std::cos(yaw);
-        const double sin_yaw = std::sin(yaw);
-
-        const double cos_diff = cos_yaw - cos_yaw_old;
-        const double sin_diff = sin_yaw - sin_yaw_old;
-
-        x +=  r * sin_diff;
-        y += -r * cos_diff;
-
-        J_pose << 1.0, 0.0, r * cos_diff,
-                  0.0, 1.0, r * sin_diff,
-                  0.0, 0.0,          1.0;
-
-        const double cos_diff_w = cos_diff * w_inv;
-        const double sin_diff_w = sin_diff * w_inv;
-
-        J_meas <<  sin_diff_w, r * (cos_yaw - sin_diff_w),
-                  -cos_diff_w, r * (sin_yaw + cos_diff_w),
-                          0.0,                        1.0;
-      }
+      J_meas << cos_yaw, 0.0,
+                sin_yaw, 0.0,
+                    0.0, 1.0;
     }
   };
 
 }  // namespace diff_drive_controller
 
-#endif /* EXACT_INTEGRATE_FUNCTOR_H_ */
+#endif /* EULER_INTEGRATE_FUNCTOR_H_ */

--- a/diff_drive_controller/include/diff_drive_controller/integrate_function.h
+++ b/diff_drive_controller/include/diff_drive_controller/integrate_function.h
@@ -41,6 +41,8 @@
 
 #include <Eigen/Core>
 
+#include <boost/shared_ptr.hpp>
+
 namespace diff_drive_controller
 {
 
@@ -53,6 +55,9 @@ namespace diff_drive_controller
       /// Pose and measurement jacobian types:
       typedef Eigen::Matrix3d             PoseJacobian;
       typedef Eigen::Matrix<double, 3, 2> MeasJacobian;
+
+      /// Pointer types:
+      typedef boost::shared_ptr<IntegrateFunction> Ptr;
 
       /**
        * \brief Constructor
@@ -87,6 +92,17 @@ namespace diff_drive_controller
       virtual void operator()(double& x, double& y, double& Y,
           const double& v_l, const double& v_r,
           PoseJacobian& J_pose, MeasJacobian& J_meas) const = 0;
+
+      /**
+       * \brief Create an integrate function with the given method and
+       * differentiation scheme
+       * \param[in] method          Integration method, which can be:
+       *                            "euler", "rungekutta2", "exact" (default)
+       * \param[in] differentiation Differentiation scheme, which can be:
+       *                            "analytic" (default), "autodiff"
+       */
+      static Ptr create(const std::string& method = "exact",
+          const std::string& differentiation = "analytic");
 
       /**
        * \brief Sets the wheel parameters: radius and separation

--- a/diff_drive_controller/include/diff_drive_controller/meas_covariance_model.h
+++ b/diff_drive_controller/include/diff_drive_controller/meas_covariance_model.h
@@ -41,6 +41,8 @@
 
 #include <Eigen/Core>
 
+#include <boost/shared_ptr.hpp>
+
 namespace diff_drive_controller
 {
 
@@ -52,6 +54,9 @@ namespace diff_drive_controller
     public:
       /// Meas(urement) covariance type:
       typedef Eigen::Matrix2d MeasCovariance;
+
+      /// Pointer types:
+      typedef boost::shared_ptr<MeasCovarianceModel> Ptr;
 
       /**
        * \brief Constructor
@@ -71,6 +76,13 @@ namespace diff_drive_controller
        * \return Meas(urement) covariance
        */
       virtual const MeasCovariance& compute(const double dp_l, const double dp_r) = 0;
+
+      /**
+       * \brief Create a meas(urement) covariance model given the model
+       * \param[in] model Meas(urement) covariance model, which can be:
+       *                  "linear" (default), "quadratic"
+       */
+      static Ptr create(const std::string& model = "linear");
 
       /**
        * \brief Left wheel covariance gain getter

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -226,6 +226,23 @@ namespace diff_drive_controller
     }
 
     /**
+     * \brief Sets the Integrate Function, if it's supported
+       * \param[in] method          Integration method, which can be:
+       *                            "euler", "rungekutta2", "exact"
+       * \param[in] differentiation Differentiation scheme, which can be:
+       *                            "analytic", "autodiff"
+     */
+    void setIntegrateFunction(const std::string& method,
+        const std::string& differentiation);
+
+    /**
+     * \brief Sets the Measurement Covariance Model, if it's supported
+     * \param[in] model Measurement Covariance model, which can be:
+     *                  "linear", "quadratic"
+     */
+    void setMeasCovarianceModel(const std::string& model);
+
+    /**
      * \brief Sets the wheel parameters: radius and separation
      * \param[in] wheel_separation   Seperation between
      *                               left and right wheels [m]
@@ -242,7 +259,7 @@ namespace diff_drive_controller
      * \param[in] wheel_resolution Wheel resolution [rad] (assumed the same for
      *                             both wheels
      */
-    void setMeasCovarianceParams(const double k_l, const double k_r,
+    void setMeasCovarianceModelParams(const double k_l, const double k_r,
         const double wheel_resolution);
 
     /**

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -145,6 +145,9 @@ namespace diff_drive_controller
     , publish_state_(config_default_.publish_state)
     , control_frequency_desired_(config_default_.control_frequency_desired)
     , control_period_desired_(1.0 / control_frequency_desired_)
+    , meas_covariance_model_("linear")
+    , integrate_method_("exact")
+    , integrate_differentiation_("analytic")
   {
   }
 
@@ -207,6 +210,19 @@ namespace diff_drive_controller
     ROS_INFO_STREAM_NAMED(name_,
         "Control period will be " <<
         (period_from_time_ ? "computed from delta in update() time inputs" : "the duration period passed to update()") << ".");
+
+    controller_nh.param("integrate_method",
+        integrate_method_, integrate_method_);
+    controller_nh.param("integrate_differentiation",
+        integrate_differentiation_, integrate_differentiation_);
+    ROS_INFO_STREAM_NAMED(name_, "Integrating odometry with method "
+                          << integrate_method_ << " and differentiation "
+                          << integrate_differentiation_ << ".");
+
+    controller_nh.param("meas_covariance_model",
+        meas_covariance_model_, meas_covariance_model_);
+    ROS_INFO_STREAM_NAMED(name_, "Using " << meas_covariance_model_
+                          << " Meas(urement) Covariance Model.");
 
     controller_nh.param("wheel_separation_multiplier",
         wheel_separation_multiplier_, wheel_separation_multiplier_);
@@ -349,7 +365,7 @@ namespace diff_drive_controller
                           << ", left wheel radius "  << wrl
                           << ", right wheel radius " << wrr);
 
-    odometry_.setMeasCovarianceParams(k_l_, k_r_, wheel_resolution_);
+    odometry_.setMeasCovarianceModelParams(k_l_, k_r_, wheel_resolution_);
     ROS_INFO_STREAM_NAMED(name_,
                           "Measurement Covariance Model params : k_l " << k_l_
                           << ", k_r " << k_r_
@@ -574,7 +590,7 @@ namespace diff_drive_controller
 
     // Set the odometry parameters:
     odometry_.setWheelParams(ws, wrl, wrr);
-    odometry_.setMeasCovarianceParams(k_l_, k_r_, wheel_resolution_);
+    odometry_.setMeasCovarianceModelParams(k_l_, k_r_, wheel_resolution_);
 
     // COMPUTE AND PUBLISH ODOMETRY
     // Read wheel joint positions and velocities:

--- a/diff_drive_controller/src/integrate_function.cpp
+++ b/diff_drive_controller/src/integrate_function.cpp
@@ -1,0 +1,116 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#include <diff_drive_controller/integrate_function.h>
+
+#include <diff_drive_controller/autodiff_integrate_function.h>
+#include <diff_drive_controller/analytic_integrate_function.h>
+
+#include <diff_drive_controller/direct_kinematics_integrate_functor.h>
+
+#include <diff_drive_controller/euler_integrate_functor.h>
+#include <diff_drive_controller/runge_kutta_2_integrate_functor.h>
+#include <diff_drive_controller/exact_integrate_functor.h>
+
+#include <boost/make_shared.hpp>
+
+namespace diff_drive_controller
+{
+
+IntegrateFunction::Ptr IntegrateFunction::create(const std::string& method,
+    const std::string& differentiation)
+{
+  typedef AnalyticIntegrateFunction<DirectKinematicsIntegrateFunctor,
+                                    EulerIntegrateFunctor>
+          AnalyticEulerIntegrateFunction;
+  typedef AnalyticIntegrateFunction<DirectKinematicsIntegrateFunctor,
+                                    RungeKutta2IntegrateFunctor>
+          AnalyticRungeKutta2IntegrateFunction;
+  typedef AnalyticIntegrateFunction<DirectKinematicsIntegrateFunctor,
+                                    ExactIntegrateFunctor>
+          AnalyticExactIntegrateFunction;
+
+  typedef AutoDiffIntegrateFunction<DirectKinematicsIntegrateFunctor,
+                                    EulerIntegrateFunctor>
+          AutoDiffEulerIntegrateFunction;
+  typedef AutoDiffIntegrateFunction<DirectKinematicsIntegrateFunctor,
+                                    RungeKutta2IntegrateFunctor>
+          AutoDiffRungeKutta2IntegrateFunction;
+  typedef AutoDiffIntegrateFunction<DirectKinematicsIntegrateFunctor,
+                                    ExactIntegrateFunctor>
+          AutoDiffExactIntegrateFunction;
+
+  if (method == "euler")
+  {
+    if (differentiation == "analytic")
+    {
+      return boost::make_shared<AnalyticEulerIntegrateFunction>();
+    }
+    else if (differentiation == "autodiff")
+    {
+      return boost::make_shared<AutoDiffEulerIntegrateFunction>();
+    }
+  }
+  else if (method == "rungekutta2")
+  {
+    if (differentiation == "analytic")
+    {
+      return boost::make_shared<AnalyticRungeKutta2IntegrateFunction>();
+    }
+    else if (differentiation == "autodiff")
+    {
+      return boost::make_shared<AutoDiffRungeKutta2IntegrateFunction>();
+    }
+  }
+  else if (method == "exact")
+  {
+    if (differentiation == "analytic")
+    {
+      return boost::make_shared<AnalyticExactIntegrateFunction>();
+    }
+    else if (differentiation == "autodiff")
+    {
+      return boost::make_shared<AutoDiffExactIntegrateFunction>();
+    }
+  }
+
+  return Ptr();
+}
+
+}  // namespace diff_drive_controller
+

--- a/diff_drive_controller/src/meas_covariance_model.cpp
+++ b/diff_drive_controller/src/meas_covariance_model.cpp
@@ -1,0 +1,64 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#include <diff_drive_controller/meas_covariance_model.h>
+
+#include <diff_drive_controller/linear_meas_covariance_model.h>
+#include <diff_drive_controller/quadratic_meas_covariance_model.h>
+
+#include <boost/make_shared.hpp>
+
+namespace diff_drive_controller
+{
+
+MeasCovarianceModel::Ptr MeasCovarianceModel::create(const std::string& model)
+{
+  if (model == "linear")
+  {
+    return boost::make_shared<LinearMeasCovarianceModel>();
+  }
+  else if (model == "quadratic")
+  {
+    return boost::make_shared<QuadraticMeasCovarianceModel>();
+  }
+
+  return Ptr();
+}
+
+}  // namespace diff_drive_controller
+

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -210,6 +210,28 @@ namespace diff_drive_controller
     return true;
   }
 
+  void Odometry::setIntegrateFunction(const std::string& method,
+      const std::string& differentiation)
+  {
+    IntegrateFunction::Ptr tmp = IntegrateFunction::create(method,
+        differentiation);
+
+    if (tmp)
+    {
+      integrate_fun_ = tmp;
+    }
+  }
+
+  void Odometry::setMeasCovarianceModel(const std::string& model)
+  {
+    MeasCovarianceModel::Ptr tmp = MeasCovarianceModel::create(model);
+
+    if (tmp)
+    {
+      meas_covariance_model_ = tmp;
+    }
+  }
+
   void Odometry::setWheelParams(const double wheel_separation,
       const double left_wheel_radius, const double right_wheel_radius)
   {
@@ -229,7 +251,8 @@ namespace diff_drive_controller
     resetAccumulators();
   }
 
-  void Odometry::setMeasCovarianceParams(const double k_l, const double k_r,
+  void Odometry::setMeasCovarianceModelParams(
+      const double k_l, const double k_r,
       const double wheel_resolution)
   {
     meas_covariance_model_->setKl(k_l);

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -42,13 +42,16 @@
 #include <diff_drive_controller/odometry.h>
 
 #include <diff_drive_controller/autodiff_integrate_function.h>
+#include <diff_drive_controller/analytic_integrate_function.h>
+
+#include <diff_drive_controller/direct_kinematics_integrate_functor.h>
+
+#include <diff_drive_controller/euler_integrate_functor.h>
+#include <diff_drive_controller/runge_kutta_2_integrate_functor.h>
+#include <diff_drive_controller/exact_integrate_functor.h>
 
 #include <diff_drive_controller/linear_meas_covariance_model.h>
 #include <diff_drive_controller/quadratic_meas_covariance_model.h>
-
-#include <diff_drive_controller/direct_kinematics_integrate_functor.h>
-#include <diff_drive_controller/runge_kutta_2_integrate_functor.h>
-#include <diff_drive_controller/exact_integrate_functor.h>
 
 #include <Eigen/Core>
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -85,9 +85,7 @@ namespace diff_drive_controller
   , v_yaw_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , integrate_fun_(
       new AutoDiffIntegrateFunction<DirectKinematicsIntegrateFunctor,
-                                    ExactIntegrateFunctor>(
-      new DirectKinematicsIntegrateFunctor<ExactIntegrateFunctor>(
-      new ExactIntegrateFunctor)))
+                                    ExactIntegrateFunctor>())
   {
     minimum_twist_covariance_.setIdentity();
     minimum_twist_covariance_ *= DEFAULT_MINIMUM_TWIST_COVARIANCE;

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -41,17 +41,8 @@
 
 #include <diff_drive_controller/odometry.h>
 
-#include <diff_drive_controller/autodiff_integrate_function.h>
-#include <diff_drive_controller/analytic_integrate_function.h>
-
-#include <diff_drive_controller/direct_kinematics_integrate_functor.h>
-
-#include <diff_drive_controller/euler_integrate_functor.h>
-#include <diff_drive_controller/runge_kutta_2_integrate_functor.h>
-#include <diff_drive_controller/exact_integrate_functor.h>
-
-#include <diff_drive_controller/linear_meas_covariance_model.h>
-#include <diff_drive_controller/quadratic_meas_covariance_model.h>
+#include <diff_drive_controller/integrate_function.h>
+#include <diff_drive_controller/meas_covariance_model.h>
 
 #include <Eigen/Core>
 
@@ -73,7 +64,7 @@ namespace diff_drive_controller
   , d_y_(0.0)
   , d_yaw_(0.0)
   , incremental_pose_dt_(0.0)
-  , meas_covariance_model_(new LinearMeasCovarianceModel())
+  , meas_covariance_model_(MeasCovarianceModel::create("linear"))
   , wheel_separation_(0.0)
   , left_wheel_radius_(0.0)
   , right_wheel_radius_(0.0)
@@ -83,9 +74,7 @@ namespace diff_drive_controller
   , v_x_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , v_y_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , v_yaw_acc_(RollingWindow::window_size = velocity_rolling_window_size)
-  , integrate_fun_(
-      new AutoDiffIntegrateFunction<DirectKinematicsIntegrateFunctor,
-                                    ExactIntegrateFunctor>())
+  , integrate_fun_(IntegrateFunction::create("exact"))
   {
     minimum_twist_covariance_.setIdentity();
     minimum_twist_covariance_ *= DEFAULT_MINIMUM_TWIST_COVARIANCE;

--- a/diff_drive_controller/test/integrate_functor_test.cpp
+++ b/diff_drive_controller/test/integrate_functor_test.cpp
@@ -1,0 +1,419 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2016, Clearpath Robotics Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+///////////////////////////////////////////////////////////////////////////////
+
+/// \author Enrique Fernandez
+
+#include "gtest_common.h"
+
+#include <diff_drive_controller/autodiff_integrate_function.h>
+#include <diff_drive_controller/analytic_integrate_function.h>
+
+#include <diff_drive_controller/direct_kinematics_integrate_functor.h>
+
+#include <diff_drive_controller/euler_integrate_functor.h>
+#include <diff_drive_controller/runge_kutta_2_integrate_functor.h>
+#include <diff_drive_controller/exact_integrate_functor.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <cmath>
+
+const double WHEEL_SEPARATION   = 0.2;  // [m]
+const double LEFT_WHEEL_RADIUS  = 0.1;  // [m]
+const double RIGHT_WHEEL_RADIUS = LEFT_WHEEL_RADIUS;  // [m]
+
+/**
+ * Test an integrate functor, which can be any of the following:
+ * EulerIntegrateFunctor
+ * RungeKutta2IntegrateFunctor
+ * ExactIntegrateFunctor
+ */
+template <class Functor>
+void testIntegrateFunctor(double& x, double& y, double& yaw,
+    const double dp_l, const double dp_r)
+{
+  // Declare auto-diff and analytic integrator types:
+  using namespace diff_drive_controller;
+
+  typedef AutoDiffIntegrateFunction<DirectKinematicsIntegrateFunctor, Functor>
+          AutoDiffIntegrator;
+  typedef AnalyticIntegrateFunction<DirectKinematicsIntegrateFunctor, Functor>
+          AnalyticIntegrator;
+
+  // Create auto-diff and analytic integrators:
+  AutoDiffIntegrator integrate_auto_diff = AutoDiffIntegrator(
+      new DirectKinematicsIntegrateFunctor<Functor>(new Functor));
+
+  integrate_auto_diff.setWheelParams(WHEEL_SEPARATION,
+          LEFT_WHEEL_RADIUS, RIGHT_WHEEL_RADIUS);
+
+  AnalyticIntegrator integrate_analytic = AnalyticIntegrator(
+      new DirectKinematicsIntegrateFunctor<Functor>(new Functor));
+
+  integrate_analytic.setWheelParams(WHEEL_SEPARATION,
+          LEFT_WHEEL_RADIUS, RIGHT_WHEEL_RADIUS);
+
+  // Integrate with auto-diff and analytic integrators:
+  const double x0   = x;
+  const double y0   = y;
+  const double yaw0 = yaw;
+
+  IntegrateFunction::PoseJacobian J_pose_auto_diff;
+  IntegrateFunction::MeasJacobian J_meas_auto_diff;
+
+  integrate_auto_diff(x, y, yaw, dp_l, dp_r,
+      J_pose_auto_diff, J_meas_auto_diff);
+
+  const double x_auto_diff   = x;
+  const double y_auto_diff   = y;
+  const double yaw_auto_diff = yaw;
+
+  x   = x0;
+  y   = y0;
+  yaw = yaw0;
+
+  IntegrateFunction::PoseJacobian J_pose_analytic;
+  IntegrateFunction::MeasJacobian J_meas_analytic;
+
+  integrate_analytic(x, y, yaw, dp_l, dp_r,
+      J_pose_analytic, J_meas_analytic);
+
+  const double x_analytic   = x;
+  const double y_analytic   = y;
+  const double yaw_analytic = yaw;
+
+  // Check the state is the same:
+  EXPECT_EQ(x_auto_diff, x_analytic);
+  EXPECT_EQ(y_auto_diff, y_analytic);
+  EXPECT_EQ(yaw_auto_diff, yaw_analytic);
+
+  // Check the Jacobians are the same:
+  const Eigen::IOFormat HeavyFmt(
+      Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+
+  EXPECT_TRUE(((J_pose_auto_diff - J_pose_analytic).array().abs() < std::numeric_limits<double>::epsilon()).all())
+    << "J_pose Auto-Diff =\n" << J_pose_auto_diff.format(HeavyFmt)
+    << "\nJ_pose Analytic =\n" << J_pose_analytic.format(HeavyFmt)
+    << "\n(J_pose Auto-Diff - J_pose Analytic) =\n" << (J_pose_auto_diff - J_pose_analytic).format(HeavyFmt);
+  EXPECT_TRUE(((J_meas_auto_diff - J_meas_analytic).array().abs() < std::numeric_limits<double>::epsilon()).all())
+    << "J_meas Auto-Diff =\n" << J_meas_auto_diff.format(HeavyFmt)
+    << "\nJ_meas Analytic =\n" << J_meas_analytic.format(HeavyFmt)
+    << "\n(J_meas Auto-Diff - J_meas Analytic) =\n" << (J_meas_auto_diff - J_meas_analytic).format(HeavyFmt);
+}
+
+/**
+ * \brief Check y-axis turning clockwise.
+ */
+template <class Functor>
+void checkYTurnClockwise(const double y, const double y0)
+{
+  // Check y-axis goes down turning clockwise:
+  EXPECT_LT(y, y0);
+}
+
+template <>
+void checkYTurnClockwise<diff_drive_controller::EulerIntegrateFunctor>(
+    const double y, const double y0)
+{
+  // Check y-axis doesn't change with Euler:
+  EXPECT_EQ(y, y0);
+}
+
+/**
+ * \brief Check y-axis turning counter-clockwise.
+ */
+template <class Functor>
+void checkYTurnCounterClockwise(const double y, const double y0)
+{
+  // Check y-axis goes up turning clockwise:
+  EXPECT_GT(y, y0);
+}
+
+template <>
+void checkYTurnCounterClockwise<diff_drive_controller::EulerIntegrateFunctor>(
+    const double y, const double y0)
+{
+  // Check y-axis doesn't change with Euler:
+  EXPECT_EQ(y, y0);
+}
+
+/**
+ * \brief Test moving forward.
+ */
+template <class Functor>
+void testForward()
+{
+  // Integrate:
+  const double dp_l = 0.1;  // [rad]
+  const double dp_r = dp_l;  // [rad]
+
+  const double x0   = 0.0;
+  const double y0   = 0.0;
+  const double yaw0 = 0.0;
+
+  double x   = x0;
+  double y   = y0;
+  double yaw = yaw0;
+
+  testIntegrateFunctor<Functor>(x, y, yaw, dp_l, dp_r);
+
+  // Check movement is forward only:
+  EXPECT_GT(x, x0);
+  EXPECT_EQ(y, y0);
+  EXPECT_EQ(yaw, yaw0);
+}
+
+/**
+ * \brief Test moving backwards.
+ */
+template <class Functor>
+void testBackwards()
+{
+  // Integrate:
+  const double dp_l = -0.1;  // [rad]
+  const double dp_r = dp_l;  // [rad]
+
+  const double x0   = 0.0;
+  const double y0   = 0.0;
+  const double yaw0 = 0.0;
+
+  double x   = x0;
+  double y   = y0;
+  double yaw = yaw0;
+
+  testIntegrateFunctor<Functor>(x, y, yaw, dp_l, dp_r);
+
+  // Check movement is backwards only:
+  EXPECT_LT(x, x0);
+  EXPECT_EQ(y, y0);
+  EXPECT_EQ(yaw, yaw0);
+}
+
+/**
+ * \brief Test turning in-place clockwise.
+ */
+template <class Functor>
+void testTurnInPlaceClockwise()
+{
+  // Integrate:
+  const double dp_l = 0.1;  // [rad]
+  const double dp_r = -dp_l;  // [rad]
+
+  const double x0   = 0.0;
+  const double y0   = 0.0;
+  const double yaw0 = 0.0;
+
+  double x   = x0;
+  double y   = y0;
+  double yaw = yaw0;
+
+  testIntegrateFunctor<Functor>(x, y, yaw, dp_l, dp_r);
+
+  // Check movement is turning in place clockwise (yaw goes down) only:
+  EXPECT_EQ(x, x0);
+  EXPECT_EQ(y, y0);
+  EXPECT_LT(yaw, yaw0);
+}
+
+/**
+ * \brief Test turning in-place counter-clockwise.
+ */
+template <class Functor>
+void testTurnInPlaceCounterClockwise()
+{
+  // Integrate:
+  const double dp_l = -0.1;  // [rad]
+  const double dp_r = -dp_l;  // [rad]
+
+  const double x0   = 0.0;
+  const double y0   = 0.0;
+  const double yaw0 = 0.0;
+
+  double x   = x0;
+  double y   = y0;
+  double yaw = yaw0;
+
+  testIntegrateFunctor<Functor>(x, y, yaw, dp_l, dp_r);
+
+  // Check movement is turning in place clockwise (yaw goes up) only:
+  EXPECT_EQ(x, x0);
+  EXPECT_EQ(y, y0);
+  EXPECT_GT(yaw, yaw0);
+}
+
+/**
+ * \brief Test turning clockwise.
+ */
+template <class Functor>
+void testTurnClockwise()
+{
+  // Integrate:
+  const double dp_l = 0.2;  // [rad]
+  const double dp_r = 0.1;  // [rad]
+
+  const double x0   = 0.0;
+  const double y0   = 0.0;
+  const double yaw0 = 0.0;
+
+  double x   = x0;
+  double y   = y0;
+  double yaw = yaw0;
+
+  testIntegrateFunctor<Functor>(x, y, yaw, dp_l, dp_r);
+
+  // Check movement is turning clockwise (yaw goes down) only:
+  EXPECT_GT(x, x0);
+  checkYTurnClockwise<Functor>(y, y0);
+  EXPECT_LT(yaw, yaw0);
+}
+
+/**
+ * \brief Test turning counter-clockwise.
+ */
+template <class Functor>
+void testTurnCounterClockwise()
+{
+  // Integrate:
+  const double dp_l = 0.1;  // [rad]
+  const double dp_r = 0.2;  // [rad]
+
+  const double x0   = 0.0;
+  const double y0   = 0.0;
+  const double yaw0 = 0.0;
+
+  double x   = x0;
+  double y   = y0;
+  double yaw = yaw0;
+
+  testIntegrateFunctor<Functor>(x, y, yaw, dp_l, dp_r);
+
+  // Check movement is turning clockwise (yaw goes up) only:
+  EXPECT_GT(x, x0);
+  checkYTurnCounterClockwise<Functor>(y, y0);
+  EXPECT_GT(yaw, yaw0);
+}
+
+// Euler tests:
+TEST(IntegrateFunctorTest, testEulerForward)
+{
+  testForward<diff_drive_controller::EulerIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testEulerBackwards)
+{
+  testBackwards<diff_drive_controller::EulerIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testEulerTurnInPlaceClockwise)
+{
+  testTurnInPlaceClockwise<diff_drive_controller::EulerIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testEulerTurnInPlaceCounterClockwise)
+{
+  testTurnInPlaceCounterClockwise<diff_drive_controller::EulerIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testEulerTurnClockwise)
+{
+  testTurnClockwise<diff_drive_controller::EulerIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testEulerTurnCounterClockwise)
+{
+  testTurnCounterClockwise<diff_drive_controller::EulerIntegrateFunctor>();
+}
+
+// RungeKutta2 tests:
+TEST(IntegrateFunctorTest, testRungeKutta2Forward)
+{
+  testForward<diff_drive_controller::RungeKutta2IntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testRungeKutta2Backwards)
+{
+  testBackwards<diff_drive_controller::RungeKutta2IntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testRungeKutta2TurnInPlaceClockwise)
+{
+  testTurnInPlaceClockwise<diff_drive_controller::RungeKutta2IntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testRungeKutta2TurnInPlaceCounterClockwise)
+{
+  testTurnInPlaceCounterClockwise<diff_drive_controller::RungeKutta2IntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testRungeKutta2TurnClockwise)
+{
+  testTurnClockwise<diff_drive_controller::RungeKutta2IntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testRungeKutta2TurnCounterClockwise)
+{
+  testTurnCounterClockwise<diff_drive_controller::RungeKutta2IntegrateFunctor>();
+}
+
+// Exact tests:
+TEST(IntegrateFunctorTest, testExactForward)
+{
+  testForward<diff_drive_controller::ExactIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testExactBackwards)
+{
+  testBackwards<diff_drive_controller::ExactIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testExactTurnInPlaceClockwise)
+{
+  testTurnInPlaceClockwise<diff_drive_controller::ExactIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testExactTurnInPlaceCounterClockwise)
+{
+  testTurnInPlaceCounterClockwise<diff_drive_controller::ExactIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testExactTurnClockwise)
+{
+  testTurnClockwise<diff_drive_controller::ExactIntegrateFunctor>();
+}
+
+TEST(IntegrateFunctorTest, testExactTurnCounterClockwise)
+{
+  testTurnCounterClockwise<diff_drive_controller::ExactIntegrateFunctor>();
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/diff_drive_controller/test/integrate_functor_test.cpp
+++ b/diff_drive_controller/test/integrate_functor_test.cpp
@@ -67,15 +67,11 @@ void testIntegrateFunctor(double& x, double& y, double& yaw,
           AnalyticIntegrator;
 
   // Create auto-diff and analytic integrators:
-  AutoDiffIntegrator integrate_auto_diff = AutoDiffIntegrator(
-      new DirectKinematicsIntegrateFunctor<Functor>(new Functor));
+  AutoDiffIntegrator integrate_auto_diff;
+  AnalyticIntegrator integrate_analytic;
 
   integrate_auto_diff.setWheelParams(WHEEL_SEPARATION,
           LEFT_WHEEL_RADIUS, RIGHT_WHEEL_RADIUS);
-
-  AnalyticIntegrator integrate_analytic = AnalyticIntegrator(
-      new DirectKinematicsIntegrateFunctor<Functor>(new Functor));
-
   integrate_analytic.setWheelParams(WHEEL_SEPARATION,
           LEFT_WHEEL_RADIUS, RIGHT_WHEEL_RADIUS);
 


### PR DESCRIPTION
Puts #27 on top of `indigo-devel`

The PR is ready for review and merge. @ayrton04 @afakihcpr @servos 

It provides:
1. Analytic Jacobians
2. Euler integration (for comparison purposes)
3. Simplify the integrate functors hierarchy, because there was no need to pass them by arguments to the constructors
4. Provide create methods (_ala_ factory pattern) to set allow the user select easily the different integrate methods, differentiation methods and also the meas(urement) covariance models; the following static params allow to select them: `intergrate_method`, `integrate_differentiation`, `meas_covariance_model`
5. Add a test for the integrate functors, that also validates the analytic Jacobians comparing them with the AutoDiff ones. All tests passes, so we **finally** switch by default to the analytic jacobians (and the autodiff is used only for testing, by default). :smiley: 
