### PR TITLE
Accumulate dt to compute twist

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -80,7 +80,6 @@ namespace diff_drive_controller
 
     /**
      * \brief Constructor
-     * Timestamp will get the current time value
      * Value will be set to zero
      * \param[in] velocity_rolling_window_size Rolling window size used to
      *                                         compute the velocity mean
@@ -89,9 +88,8 @@ namespace diff_drive_controller
 
     /**
      * \brief Initialize the odometry
-     * \param[in] time Current time
      */
-    void init(const ros::Time &time);
+    void init();
 
     /**
      * \brief Updates the odometry class with latest wheels position, i.e. in
@@ -123,13 +121,10 @@ namespace diff_drive_controller
      * \brief Update the odometry twist with the (internal) incremental pose,
      * since the last update/call to this method; this resets the (internal)
      * incremental pose
-     * \param[in] time Current time, used to compute the time step/increment,
-     *                 which is used to divide the (internal) incremental pose
-     *                 by dt and obtain the twist
      * \return true if twist is actually updated; it won't be updated if the
      *         time step/increment is very small, to avoid division by zero
      */
-    bool updateTwist(const ros::Time& time);
+    bool updateTwist();
 
     /**
      * \brief Heading getter
@@ -288,10 +283,6 @@ namespace diff_drive_controller
      */
     void resetAccumulators();
 
-    /// Timestamp for last twist computed, ie. since when the (internal)
-    /// incremental pose has been computed:
-    ros::Time timestamp_twist_;
-
     /// Current pose:
     double x_;        //   [m]
     double y_;        //   [m]
@@ -301,6 +292,10 @@ namespace diff_drive_controller
     double d_x_;    //   [m]
     double d_y_;    //   [m]
     double d_yaw_;  // [rad]
+
+    /// Incremental pose time interval, which accumulates the time steps
+    /// (control periods):
+    double incremental_pose_dt_;  // [s]
 
     /// Current velocity:
     double v_x_;    //   [m/s]

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -607,6 +607,8 @@ namespace diff_drive_controller
     }
 
     // Compute/Set control period and frequency (desired/expected or real):
+    // @todo also allow to compute the period as time - time_previous_, because
+    // they can be different
     const double control_period    = control_period_desired_    > 0.0 ? control_period_desired_    : period.toSec();
     const double control_frequency = control_frequency_desired_ > 0.0 ? control_frequency_desired_ : 1.0 / control_period;
 
@@ -667,7 +669,7 @@ namespace diff_drive_controller
       // Note that the twist must be computed at the same frequency that it gets
       // published, because otherwise the code that uses it cannot apply the
       // same period it was used to compute it.
-      odometry_.updateTwist(time);
+      odometry_.updateTwist();
 
       last_odom_publish_time_ = time;
 
@@ -973,7 +975,7 @@ namespace diff_drive_controller
     // Register starting time used to keep fixed rate
     last_odom_publish_time_ = last_odom_tf_publish_time_ = time;
 
-    odometry_.init(time);
+    odometry_.init();
   }
 
   void DiffDriveController::stopping(const ros::Time& /*time*/)

--- a/diff_drive_controller/test/odometry_test.cpp
+++ b/diff_drive_controller/test/odometry_test.cpp
@@ -175,7 +175,7 @@ TEST(OdometryTest, testIntegrateMotionNoMoveFromInitial)
       CONTROL_STEPS, CONTROL_PERIOD, 0.0, 0.0);
 
   // Update the twist (from the internal incremental odometry pose):
-  EXPECT_TRUE(odometry.updateTwist(t));
+  EXPECT_TRUE(odometry.updateTwist());
 
   // Retrieve new/current pose and twist state and covariance:
   const double x_1   = odometry.getX();
@@ -292,7 +292,7 @@ TEST(OdometryTest, testIntegrateMotionForwardFromInitial)
       CONTROL_STEPS, CONTROL_PERIOD, POSITION_INCREMENT, POSITION_INCREMENT);
 
   // Update the twist (from the internal incremental odometry pose):
-  EXPECT_TRUE(odometry.updateTwist(t));
+  EXPECT_TRUE(odometry.updateTwist());
 
   // Retrieve new/current pose and twist state and covariance:
   const double x_1   = odometry.getX();
@@ -374,7 +374,7 @@ TEST(OdometryTest, testIntegrateMotionForwardFromNotInitial)
       CONTROL_STEPS, CONTROL_PERIOD, POSITION_INCREMENT, 2 * POSITION_INCREMENT);
 
   // Update the twist (from the internal incremental odometry pose):
-  EXPECT_TRUE(odometry.updateTwist(t));
+  EXPECT_TRUE(odometry.updateTwist());
 
   // Save initial/current pose and twist state and covariance:
   const double x_0   = odometry.getX();
@@ -394,7 +394,7 @@ TEST(OdometryTest, testIntegrateMotionForwardFromNotInitial)
       CONTROL_STEPS, CONTROL_PERIOD, POSITION_INCREMENT, POSITION_INCREMENT);
 
   // Update the twist (from the internal incremental odometry pose):
-  EXPECT_TRUE(odometry.updateTwist(t));
+  EXPECT_TRUE(odometry.updateTwist());
 
   // Retrieve new/current pose and twist state and covariance:
   const double x_1   = odometry.getX();


### PR DESCRIPTION
Note that in the update method period != time - time_previous, so we
have to accumulate the dt for the incremental pose to compute the twist
properly.

@servos 
