### PR TITLE
Add period_from_time param

### DIFF
--- a/diff_drive_controller/cfg/DiffDriveController.cfg
+++ b/diff_drive_controller/cfg/DiffDriveController.cfg
@@ -9,6 +9,8 @@ gen = ParameterGenerator()
 gen.add("pose_from_joint_position", bool_t, 0, "Compute odometry pose from wheel joint position.", True)
 gen.add("twist_from_joint_position", bool_t, 0, "Compute odometry twist from wheel joint position.", False)
 
+gen.add("period_from_time", bool_t, 0, "Compute the control period from time.", False)
+
 gen.add("wheel_separation_multiplier",  double_t, 0, "Wheel separation multiplier.", 1.0, 0.5, 1.5)
 gen.add("left_wheel_radius_multiplier",  double_t, 0, "Left wheel radius multiplier.", 1.0, 0.5, 1.5)
 gen.add("right_wheel_radius_multiplier",  double_t, 0, "Right wheel radius multiplier.", 1.0, 0.5, 1.5)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -124,6 +124,8 @@ namespace diff_drive_controller
     bool pose_from_joint_position_;
     bool twist_from_joint_position_;
 
+    bool period_from_time_;
+
     bool use_position_;
     bool use_velocity_;
 
@@ -186,6 +188,8 @@ namespace diff_drive_controller
     double left_velocity_limited_previous_;
     double right_velocity_limited_previous_;
 
+    ros::Time time_previous_;
+
     /// Dynamic reconfigure server related:
     typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
     boost::shared_ptr<ReconfigureServer> cfg_server_;
@@ -199,6 +203,8 @@ namespace diff_drive_controller
     {
       bool pose_from_joint_position;
       bool twist_from_joint_position;
+
+      bool period_from_time;
 
       double wheel_separation_multiplier;
       double left_wheel_radius_multiplier;
@@ -217,6 +223,7 @@ namespace diff_drive_controller
       DynamicParams()
         : pose_from_joint_position(true)
         , twist_from_joint_position(false)
+        , period_from_time(false)
         , wheel_separation_multiplier(1.0)
         , left_wheel_radius_multiplier(1.0)
         , right_wheel_radius_multiplier(1.0)

--- a/diff_drive_controller/msg/DiffDriveControllerState.msg
+++ b/diff_drive_controller/msg/DiffDriveControllerState.msg
@@ -37,6 +37,10 @@ float64 control_period_desired
 float64 control_period_actual
 float64 control_period_error
 
+# Control period estimated from the time differences:
+float64 control_period_actual_estimated
+float64 control_period_error_estimated
+
 # Control time (of the actual code):
 # Note that the resolution of the wall time is approx. 0.5us, but the user and
 # system is only 10ms. See:

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -621,8 +621,17 @@ namespace diff_drive_controller
     // Compute the period estimated from time:
     const ros::Duration period_estimated = time - time_previous_;
 
-    // Compute/Set control period and frequency (desired/expected or real):
-    const double control_period    = control_period_desired_    > 0.0 ? control_period_desired_    : (period_from_time_ ? period_estimated.toSec() : period.toSec());
+    // Compute/Set control period (desired/expected or real):
+    const double control_period = control_period_desired_ > 0.0 ? control_period_desired_ : (period_from_time_ ? period_estimated.toSec() : period.toSec());
+
+    // Skip cycle if control period <= 0.0:
+    if (control_period <= 0.0)
+    {
+      // @todo add a diagnostic message
+      return;
+    }
+
+    // Compute/Set control frequency (desired/expected or real):
     const double control_frequency = control_frequency_desired_ > 0.0 ? control_frequency_desired_ : 1.0 / control_period;
 
     // Compute wheel joints positions estimated from the velocities:

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -126,6 +126,7 @@ namespace diff_drive_controller
     : open_loop_(false)
     , pose_from_joint_position_(config_default_.pose_from_joint_position)
     , twist_from_joint_position_(config_default_.twist_from_joint_position)
+    , period_from_time_(config_default_.period_from_time)
     , command_struct_()
     , dynamic_params_struct_()
     , wheel_separation_(0.0)
@@ -201,6 +202,11 @@ namespace diff_drive_controller
 
     use_position_ =  pose_from_joint_position_ ||  twist_from_joint_position_;
     use_velocity_ = !pose_from_joint_position_ || !twist_from_joint_position_;
+
+    controller_nh.param("period_from_time", period_from_time_, period_from_time_);
+    ROS_INFO_STREAM_NAMED(name_,
+        "Control period will be " <<
+        (period_from_time_ ? "computed from delta in update() time inputs" : "the duration period passed to update()") << ".");
 
     controller_nh.param("wheel_separation_multiplier",
         wheel_separation_multiplier_, wheel_separation_multiplier_);
@@ -352,6 +358,8 @@ namespace diff_drive_controller
     dynamic_params_struct_.pose_from_joint_position = pose_from_joint_position_;
     dynamic_params_struct_.twist_from_joint_position = twist_from_joint_position_;
 
+    dynamic_params_struct_.period_from_time = period_from_time_;
+
     dynamic_params_struct_.wheel_separation_multiplier = wheel_separation_multiplier_;
 
     dynamic_params_struct_.left_wheel_radius_multiplier  = left_wheel_radius_multiplier_;
@@ -375,6 +383,8 @@ namespace diff_drive_controller
     DiffDriveControllerConfig config(config_default_);
     config.pose_from_joint_position = pose_from_joint_position_;
     config.twist_from_joint_position = twist_from_joint_position_;
+
+    config.period_from_time = period_from_time_;
 
     config.wheel_separation_multiplier = wheel_separation_multiplier_;
 
@@ -540,6 +550,8 @@ namespace diff_drive_controller
     pose_from_joint_position_ = dynamic_params.pose_from_joint_position;
     twist_from_joint_position_ = dynamic_params.twist_from_joint_position;
 
+    period_from_time_ = dynamic_params.period_from_time;
+
     wheel_separation_multiplier_ = dynamic_params.wheel_separation_multiplier;
     left_wheel_radius_multiplier_ = dynamic_params.left_wheel_radius_multiplier;
     right_wheel_radius_multiplier_ = dynamic_params.right_wheel_radius_multiplier;
@@ -606,10 +618,11 @@ namespace diff_drive_controller
       }
     }
 
+    // Compute the period estimated from time:
+    const ros::Duration period_estimated = time - time_previous_;
+
     // Compute/Set control period and frequency (desired/expected or real):
-    // @todo also allow to compute the period as time - time_previous_, because
-    // they can be different
-    const double control_period    = control_period_desired_    > 0.0 ? control_period_desired_    : period.toSec();
+    const double control_period    = control_period_desired_    > 0.0 ? control_period_desired_    : (period_from_time_ ? period_estimated.toSec() : period.toSec());
     const double control_frequency = control_frequency_desired_ > 0.0 ? control_frequency_desired_ : 1.0 / control_period;
 
     // Compute wheel joints positions estimated from the velocities:
@@ -925,6 +938,9 @@ namespace diff_drive_controller
         state_pub_->msg_.control_period_actual  = period.toSec();
         state_pub_->msg_.control_period_error   = state_pub_->msg_.control_period_desired - state_pub_->msg_.control_period_actual;
 
+        state_pub_->msg_.control_period_actual_estimated = period_estimated.toSec();
+        state_pub_->msg_.control_period_error_estimated = state_pub_->msg_.control_period_desired - state_pub_->msg_.control_period_actual_estimated;
+
         // Set control wall, user and system time:
         boost::timer::cpu_times control_times = cpu_timer_.elapsed();
 
@@ -966,6 +982,9 @@ namespace diff_drive_controller
       left_positions_previous_[i] = left_positions_[i];
       right_positions_previous_[i] = right_positions_[i];
     }
+
+    // Save time, needed to estimate the period:
+    time_previous_ = time;
   }
 
   void DiffDriveController::starting(const ros::Time& time)
@@ -973,7 +992,7 @@ namespace diff_drive_controller
     brake();
 
     // Register starting time used to keep fixed rate
-    last_odom_publish_time_ = last_odom_tf_publish_time_ = time;
+    last_odom_publish_time_ = last_odom_tf_publish_time_ = time_previous_ = time;
 
     odometry_.init();
   }
@@ -1019,6 +1038,8 @@ namespace diff_drive_controller
     dynamic_params_struct_.pose_from_joint_position = config.pose_from_joint_position;
     dynamic_params_struct_.twist_from_joint_position = config.twist_from_joint_position;
 
+    dynamic_params_struct_.period_from_time = config.period_from_time;
+
     dynamic_params_struct_.wheel_separation_multiplier = config.wheel_separation_multiplier;
 
     dynamic_params_struct_.left_wheel_radius_multiplier  = config.left_wheel_radius_multiplier;
@@ -1038,8 +1059,9 @@ namespace diff_drive_controller
 
     ROS_DEBUG_STREAM_NAMED(name_,
                           "Reconfigured Odometry params. "
-                          << "pose odometry computed from: " << (dynamic_params_struct_.pose_from_joint_position ? "position" : "velocity") << ", "
-                          << "twist odometry computed from: " << (dynamic_params_struct_.twist_from_joint_position ? "position" : "velocity") << ", "
+                          << "pose odometry computed from wheel joint: " << (dynamic_params_struct_.pose_from_joint_position ? "position" : "velocity") << ", "
+                          << "twist odometry computed from wheel joint: " << (dynamic_params_struct_.twist_from_joint_position ? "position" : "velocity") << ", "
+                          << "control period: " << (dynamic_params_struct_.period_from_time ? "computed from delta in update() time inputs" : "duration passed to update()") << ", "
                           << "wheel separation:   " << dynamic_params_struct_.wheel_separation_multiplier << ", "
                           << "left wheel radius:  " << dynamic_params_struct_.left_wheel_radius_multiplier << ", "
                           << "right wheel radius: " << dynamic_params_struct_.left_wheel_radius_multiplier);


### PR DESCRIPTION
This allows the user to use the `period` or the `time` differences between calls to the `update` method.

It also publishes the period estimated from time on the state, so it's easy to compared the `period` vs the `time` differences, regardless of the value of the parameter `period_from_time`, which defaults to `False` because the `period` is more accurate and it's (usually) monotonic/steady, ie. `period >= 0` (indeed, it's usually `> 0`).

@mikepurvis 
