### PR TITLE
Update to tf2 and package format 2

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -9,7 +9,9 @@ find_package(catkin REQUIRED
     controller_interface
     urdf
     realtime_tools
-    tf
+    tf2
+    tf2_msgs
+    tf2_geometry_msgs
     std_msgs
     geometry_msgs
     nav_msgs
@@ -84,7 +86,8 @@ if (CATKIN_ENABLE_TESTING)
       std_srvs
       controller_manager
       control_toolbox
-      tf)
+      tf2
+      tf2_ros)
 
   find_package(Eigen COMPONENTS)
 

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -46,7 +46,7 @@
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <diff_drive_controller/DiffDriveControllerState.h>
-#include <tf/tfMessage.h>
+#include <tf2_msgs/TFMessage.h>
 
 #include <dynamic_reconfigure/server.h>
 
@@ -148,7 +148,7 @@ namespace diff_drive_controller
 
     /// Odometry related:
     boost::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
-    boost::shared_ptr<realtime_tools::RealtimePublisher<tf::tfMessage> > tf_odom_pub_;
+    boost::shared_ptr<realtime_tools::RealtimePublisher<tf2_msgs::TFMessage> > tf_odom_pub_;
     Odometry odometry_;
 
     boost::shared_ptr<realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped> > cmd_vel_limited_pub_;

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -1,8 +1,9 @@
-<package>
+<package format="2">
   <name>diff_drive_controller</name>
   <version>0.9.2</version>
   <description>Controller for a differential drive mobile base.</description>
   <maintainer email="bence.magyar@pal-robotics.com">Bence Magyar</maintainer>
+  <maintainer email="efernandez@clearpathrobotics.com">Enrique Fernandez</maintainer>
 
   <license>BSD</license>
 
@@ -11,44 +12,37 @@
   <url type="repository">https://github.com/ros-controls/ros_controllers</url>
 
   <author email="bence.magyar@pal-robotics.com">Bence Magyar</author>
+  <author email="efernandez@clearpathrobotics.com">Enrique Fernandez</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>controller_interface</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>realtime_tools</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>urdf</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>libceres-dev</build_depend>
   <build_depend>roslint</build_depend>
-  <build_depend>boost</build_depend>
 
-  <run_depend>message_runtime</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>controller_interface</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>realtime_tools</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>urdf</run_depend>
-  <run_depend>boost</run_depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>dynamic_reconfigure</depend>
+  <depend>controller_interface</depend>
+  <depend>realtime_tools</depend>
+  <depend>urdf</depend>
+  <depend>boost</depend>
 
-  <!--Tests-->
-  <build_depend>rostest</build_depend>
+  <exec_depend>message_runtime</exec_depend>
 
+  <test_depend>rostest</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>control_toolbox</test_depend>
+  <test_depend>tf2_ros</test_depend>
   <test_depend>xacro</test_depend>
   <test_depend>rqt_plot</test_depend>
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -42,7 +42,7 @@
 #include <algorithm>
 #include <numeric>
 
-#include <tf/transform_datatypes.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <urdf_parser/urdf_parser.h>
 
@@ -736,13 +736,13 @@ namespace diff_drive_controller
       last_odom_publish_time_ = time;
 
       // Populate odom message and publish:
-      const geometry_msgs::Quaternion orientation(
-            tf::createQuaternionMsgFromYaw(odometry_.getHeading()));
+      tf2::Quaternion q;
+      q.setRPY(0.0, 0.0, odometry_.getHeading());
 
       odom_pub_->msg_.header.stamp = time;
       odom_pub_->msg_.pose.pose.position.x = odometry_.getX();
       odom_pub_->msg_.pose.pose.position.y = odometry_.getY();
-      odom_pub_->msg_.pose.pose.orientation = orientation;
+      odom_pub_->msg_.pose.pose.orientation = tf2::toMsg(q);
 
       odom_pub_->msg_.twist.twist.linear.x  = odometry_.getVx();
       odom_pub_->msg_.twist.twist.linear.y  = odometry_.getVy();
@@ -768,14 +768,14 @@ namespace diff_drive_controller
       last_odom_tf_publish_time_ = time;
 
       // Populate tf odometry frame message and publish:
-      const geometry_msgs::Quaternion orientation(
-            tf::createQuaternionMsgFromYaw(odometry_.getHeading()));
+      tf2::Quaternion q;
+      q.setRPY(0.0, 0.0, odometry_.getHeading());
 
       geometry_msgs::TransformStamped& odom_frame = tf_odom_pub_->msg_.transforms[0];
       odom_frame.header.stamp = time;
       odom_frame.transform.translation.x = odometry_.getX();
       odom_frame.transform.translation.y = odometry_.getY();
-      odom_frame.transform.rotation = orientation;
+      odom_frame.transform.rotation = tf2::toMsg(q);
       tf_odom_pub_->unlockAndPublish();
     }
 
@@ -1276,7 +1276,7 @@ namespace diff_drive_controller
     odom_pub_->msg_.twist.covariance.fill(0);
 
     /// Setup odometry realtime publisher
-    tf_odom_pub_.reset(new realtime_tools::RealtimePublisher<tf::tfMessage>(root_nh, "/tf", 100));
+    tf_odom_pub_.reset(new realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>(root_nh, "/tf", 100));
     tf_odom_pub_->msg_.transforms.resize(1);
     tf_odom_pub_->msg_.transforms[0].transform.translation.z = 0.0;
     tf_odom_pub_->msg_.transforms[0].child_frame_id = base_frame_id_;

--- a/diff_drive_controller/test/diff_drive_odom_tf_test.cpp
+++ b/diff_drive_controller/test/diff_drive_odom_tf_test.cpp
@@ -28,7 +28,7 @@
 /// \author Bence Magyar
 
 #include "test_common.h"
-#include <tf/transform_listener.h>
+#include <tf2_ros/transform_listener.h>
 
 // TEST CASES
 TEST_F(DiffDriveControllerTest, testNoOdomFrame)
@@ -38,11 +38,12 @@ TEST_F(DiffDriveControllerTest, testNoOdomFrame)
   {
     ros::Duration(0.1).sleep();
   }
-  // set up tf listener
-  tf::TransformListener listener;
+  // set up tf buffer core
+  tf2_ros::Buffer tf_buffer;
+  tf2_ros::TransformListener listener(tf_buffer);
   ros::Duration(2.0).sleep();
   // check the odom frame doesn't exist
-  EXPECT_FALSE(listener.frameExists("odom"));
+  EXPECT_FALSE(tf_buffer._frameExists("odom"));
 }
 
 int main(int argc, char** argv)

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -35,8 +35,10 @@
 #include <ros/ros.h>
 
 #include <geometry_msgs/Twist.h>
+#include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Odometry.h>
-#include <tf/tf.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/utils.h>
 #include <control_toolbox/pid.h>
 #include <angles/angles.h>
 
@@ -105,7 +107,11 @@ public:
     {
       // Retrieve current state:
       const nav_msgs::Odometry odom = getLastOdom();
-      const double yaw = tf::getYaw(odom.pose.pose.orientation);
+
+      tf2::Quaternion q;
+      tf2::fromMsg(odom.pose.pose.orientation, q);
+
+      const double yaw = tf2::getYaw(q);
 
       // Compute error wrt target:
       const double error = angles::shortest_angular_distance(yaw, target);
@@ -184,11 +190,6 @@ private:
   }
 
 };
-
-inline tf::Quaternion tfQuatFromGeomQuat(const geometry_msgs::Quaternion& quat)
-{
-  return tf::Quaternion(quat.x, quat.y, quat.z, quat.w);
-}
 
 void propagate(double& x, double& y, double& yaw,
     double v_x, double v_y, double v_yaw, double dt)


### PR DESCRIPTION
All tests passing as before.

The orientation quaternion published in the odometry message still have `q.w` in the `[-1.0, 1.0]` range, i.e. nothing seems to force `q.w >= 0.0`.

Anyway, this migration would be needed regardless of that. I can investigate later the actual reason that here `q.w` is NOT force to be `>= 0.0` but in **robot_localization** is.

@afakihcpr 
