### PR TITLE
Brake (0 velocity) on NaN

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -638,6 +638,8 @@ namespace diff_drive_controller
         if (std::isnan(left_positions_[i]) ||
             std::isnan(right_positions_[i]))
         {
+          brake();
+
           // @todo add a diagnostic message
           return;
         }
@@ -652,6 +654,8 @@ namespace diff_drive_controller
         if (std::isnan(left_velocities_[i]) ||
             std::isnan(right_velocities_[i]))
         {
+          brake();
+
           // @todo add a diagnostic message
           return;
         }


### PR DESCRIPTION
It's clearly safer to set the velocity to 0 when there NaN on the feedback as a safety measure.

Now the previous velocity command is latched on the joint controllers.
