### PR TITLE
Make wheel speed limiter function virtual

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -123,6 +123,43 @@ namespace diff_drive_controller
       wheel_speed_limiter_ = wheel_speed_limiter;
     }
 
+  protected:
+    /**
+     * \brief Default wheel speed limiter function
+     * \param [in, out] left_velocity  Left wheel velocity (not used)
+     * \param [in, out] right_velocity Right wheel velocity (not used)
+     */
+    virtual void wheelSpeedLimiter(double& left, double& right)
+    {
+      if (wheel_speed_limiter_)
+      {
+        wheel_speed_limiter_(left, right);
+      }
+    }
+
+    /**
+     * \brief Brakes the wheels, i.e. sets the velocity to 0
+     */
+    void brake();
+
+    /// Wheel radius (assuming it's the same for the left and right wheels):
+    double wheel_radius_;
+
+    /// Wheel separation, wrt the midpoint of the wheel width:
+    double wheel_separation_;
+
+    /// Wheel separation and radius calibration multipliers:
+    double wheel_separation_multiplier_;
+    double left_wheel_radius_multiplier_;
+    double right_wheel_radius_multiplier_;
+
+    /// Positions and velocities from the encoders:
+    std::vector<double> left_positions_;
+    std::vector<double> right_positions_;
+
+    std::vector<double> left_velocities_;
+    std::vector<double> right_velocities_;
+
   private:
     std::string name_;
 
@@ -165,12 +202,6 @@ namespace diff_drive_controller
     boost::shared_ptr<realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped> > cmd_vel_limited_pub_;
 
     boost::shared_ptr<realtime_tools::RealtimePublisher<DiffDriveControllerState> > state_pub_;
-
-    std::vector<double> left_positions_;
-    std::vector<double> right_positions_;
-
-    std::vector<double> left_velocities_;
-    std::vector<double> right_velocities_;
 
     std::vector<double> left_positions_estimated_;
     std::vector<double> right_positions_estimated_;
@@ -249,17 +280,6 @@ namespace diff_drive_controller
     realtime_tools::RealtimeBuffer<DynamicParams> dynamic_params_;
     DynamicParams dynamic_params_struct_;
 
-    /// Wheel separation, wrt the midpoint of the wheel width:
-    double wheel_separation_;
-
-    /// Wheel radius (assuming it's the same for the left and right wheels):
-    double wheel_radius_;
-
-    /// Wheel separation and radius calibration multipliers:
-    double wheel_separation_multiplier_;
-    double left_wheel_radius_multiplier_;
-    double right_wheel_radius_multiplier_;
-
     /// Measurement Covariance Model multipliers:
     double k_l_;
     double k_r_;
@@ -317,11 +337,6 @@ namespace diff_drive_controller
     std::string integrate_method_;
     std::string integrate_differentiation_;
   private:
-    /**
-     * \brief Brakes the wheels, i.e. sets the velocity to 0
-     */
-    void brake();
-
     /**
      * \brief Velocity command callback
      * \param command Velocity command message (twist)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -119,15 +119,6 @@ static bool getWheelRadius(
   return true;
 }
 
-/*
- * \brief Dummy wheel speed limiter function
- * \param [in, out] left_velocity  Left wheel velocity (not used)
- * \param [in, out] right_velocity Right wheel velocity (not used)
- */
-static void wheelSpeedLimiterDummy(double&, double&)
-{
-  // do nothing
-}
 
 namespace diff_drive_controller
 {
@@ -221,7 +212,6 @@ namespace diff_drive_controller
     , base_frame_id_("base_link")
     , enable_odom_tf_(true)
     , wheel_joints_size_(0)
-    , wheel_speed_limiter_(wheelSpeedLimiterDummy)
     , publish_cmd_vel_limited_(config_default_.publish_cmd_vel_limited)
     , publish_state_(config_default_.publish_state)
     , control_frequency_desired_(config_default_.control_frequency_desired)
@@ -828,7 +818,7 @@ namespace diff_drive_controller
     double right_velocity_limited = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/wrr;
 
     // Limit wheels velocities:
-    wheel_speed_limiter_(left_velocity_limited, right_velocity_limited);
+    wheelSpeedLimiter(left_velocity_limited, right_velocity_limited);
 
     // Compute linear and angular velocities:
     // @todo provide method and share it with


### PR DESCRIPTION
A controller that inherits from `DiffDriveController` can now override the `wheelSpeedLimiter` function instead of using the `setWheelSpeedLimiter` functionality. 

The `wheel_radius_` is protected since it is needed by any child classes to convert between rad/s and m/s.
