### PR TITLE
Move plugin to separate shared object.

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -47,6 +47,7 @@ catkin_package(
     message_runtime
     std_msgs
     trajectory_msgs
+    urdf
   DEPENDS
     Boost
     Eigen)

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -37,6 +37,9 @@ generate_messages(
 
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)
 
+# We intentionally only export the non-plugin library. Packages which find_package this package
+# should still only be linking against the non-plugin library (for example, to compile a
+# derived controller which is itself a plugin).
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -74,7 +77,7 @@ add_library(${PROJECT_NAME}_plugin
   src/diff_drive_controller_plugin.cpp)
 target_link_libraries(${PROJECT_NAME}_plugin ${PROJECT_NAME})
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -70,6 +70,10 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
+add_library(${PROJECT_NAME}_plugin
+  src/diff_drive_controller_plugin.cpp)
+target_link_libraries(${PROJECT_NAME}_plugin ${PROJECT_NAME})
+
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/diff_drive_controller/diff_drive_controller_plugins.xml
+++ b/diff_drive_controller/diff_drive_controller_plugins.xml
@@ -1,4 +1,4 @@
-<library path="lib/libdiff_drive_controller">
+<library path="lib/libdiff_drive_controller_plugin">
 
   <class name="diff_drive_controller/DiffDriveController" type="diff_drive_controller::DiffDriveController" base_class_type="controller_interface::ControllerBase">
     <description>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -1306,10 +1306,4 @@ namespace diff_drive_controller
     tf_odom_pub_->msg_.transforms[0].header.frame_id = "odom";
   }
 
-
-} // namespace diff_drive_controller
-
-#include <pluginlib/class_list_macros.h>
-
-PLUGINLIB_EXPORT_CLASS(diff_drive_controller::DiffDriveController,
-    controller_interface::ControllerBase);
+}  // namespace diff_drive_controller

--- a/diff_drive_controller/src/diff_drive_controller_plugin.cpp
+++ b/diff_drive_controller/src/diff_drive_controller_plugin.cpp
@@ -1,0 +1,43 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016 Clearpath Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PAL Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ * Author: Mike Purvis
+ */
+
+#include <diff_drive_controller/diff_drive_controller.h>
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(diff_drive_controller::DiffDriveController,
+    controller_interface::ControllerBase);


### PR DESCRIPTION
This addresses the issue with derived controllers linking against DiffDriveController directly and violating that prohibition in class_loader:

http://wiki.ros.org/class_loader#Caution_of_Linking_Directly_Against_Plugin_Libraries

@efernandez FYI

@dirk-thomas Does this seem like a correct approach to you?
