### PR TITLE
Virtual destructor for DiffDriveController.

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -84,6 +84,8 @@ namespace diff_drive_controller
 
     DiffDriveController();
 
+    virtual ~DiffDriveController();
+
     /**
      * \brief Initialize controller
      * \param hw            Velocity joint interface for the wheels

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -222,6 +222,10 @@ namespace diff_drive_controller
   {
   }
 
+  DiffDriveController::~DiffDriveController()
+  {
+  }
+
   bool DiffDriveController::init(hardware_interface::VelocityJointInterface* hw,
             ros::NodeHandle& root_nh,
             ros::NodeHandle &controller_nh)


### PR DESCRIPTION
Now that we have classes extending this, it requires a virtual destructor.
