### PR TITLE
Added desired wheel velocity parameters to wheelSpeedLimiter.

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -126,10 +126,14 @@ namespace diff_drive_controller
     /**
      * \brief Default wheel speed limiter function, can be overridden
      *        in a controller which extends this one.
-     * \param [in, out] left_command  Commanded left wheel velocity.
-     * \param [in, out] right_command Commanded right wheel velocity.
-     * \param [in]      left_desired  Desired left wheel velocity.
-     * \param [in]      right_desired Desired right wheel velocity.
+     * \param [in, out] left_command  The next velocity command to be sent to the left wheel subject to velocity and
+     *                                acceleration constraints. [rad/s]
+     * \param [in, out] right_command The next velocity command to be sent to the right wheel subject to velocity and
+     *                                acceleration constraints. [rad/s]
+     * \param [in]      left_desired  The desired left wheel velocity at steady state (i.e. after it has finished
+     *                                accelerating/decelerating). [rad/s]
+     * \param [in]      right_desired The desired right wheel velocity at steady state (i.e. after it has finished
+     *                                accelerating/decelerating). [rad/s]
      */
     virtual void wheelSpeedLimiter(double& left_command, double& right_command,
                                    double left_desired, double right_desired);

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -80,7 +80,7 @@ namespace diff_drive_controller
       : public controller_interface::Controller<hardware_interface::VelocityJointInterface>
   {
   public:
-    typedef boost::function<void (double&, double&)> WheelSpeedLimiter;
+    typedef boost::function<void (double&, double&, double, double)> WheelSpeedLimiter;
 
     DiffDriveController();
 
@@ -126,10 +126,13 @@ namespace diff_drive_controller
     /**
      * \brief Default wheel speed limiter function, can be overridden
      *        in a controller which extends this one.
-     * \param [in, out] left_velocity  Left wheel velocity (not used)
-     * \param [in, out] right_velocity Right wheel velocity (not used)
+     * \param [in, out] left_command  Commanded left wheel velocity.
+     * \param [in, out] right_command Commanded right wheel velocity.
+     * \param [in]      left_desired  Desired left wheel velocity.
+     * \param [in]      right_desired Desired right wheel velocity.
      */
-    virtual void wheelSpeedLimiter(double& left, double& right);
+    virtual void wheelSpeedLimiter(double& left_command, double& right_command,
+                                   double left_desired, double right_desired);
 
     /**
      * \brief Velocity command callback

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -834,7 +834,7 @@ namespace diff_drive_controller
     double right_velocity_limited = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/wrr;
 
     // Limit wheels velocities:
-    wheelSpeedLimiter(left_velocity_limited, right_velocity_limited);
+    wheelSpeedLimiter(left_velocity_limited, right_velocity_limited, left_velocity_desired, right_velocity_desired);
 
     // Compute linear and angular velocities:
     // @todo provide method and share it with
@@ -1062,11 +1062,12 @@ namespace diff_drive_controller
     wheel_speed_limiter_ = wheel_speed_limiter;
   }
 
-  void DiffDriveController::wheelSpeedLimiter(double& left, double& right)
+  void DiffDriveController::wheelSpeedLimiter(double& left_command, double& right_command,
+                                              double left_desired, double right_desired)
   {
     if (wheel_speed_limiter_)
     {
-      wheel_speed_limiter_(left, right);
+      wheel_speed_limiter_(left_command, right_command, left_desired, right_desired);
     }
   }
 


### PR DESCRIPTION
Both Rocksteady and RZR bind their RVI speed limit function to wheelSpeedLimiter in diff_drive_controller. One current issue is that wheelSpeedLimiter only takes the current commands as inputs. These commands may be acceleration limited already, in which case each successive input is just a small step. By having the desired velocity as a parameter, RVI will be able to know the desired steady state velocity in such cases.