### PR TITLE
Use eigen aligned allocator

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/meas_covariance_model.h
+++ b/diff_drive_controller/include/diff_drive_controller/meas_covariance_model.h
@@ -55,6 +55,8 @@ namespace diff_drive_controller
       /// Meas(urement) covariance type:
       typedef Eigen::Matrix2d MeasCovariance;
 
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
       /// Pointer types:
       typedef boost::shared_ptr<MeasCovarianceModel> Ptr;
 

--- a/diff_drive_controller/src/integrate_function.cpp
+++ b/diff_drive_controller/src/integrate_function.cpp
@@ -79,33 +79,39 @@ IntegrateFunction::Ptr IntegrateFunction::create(const std::string& method,
   {
     if (differentiation == "analytic")
     {
-      return boost::make_shared<AnalyticEulerIntegrateFunction>();
+      return boost::allocate_shared<AnalyticEulerIntegrateFunction>(
+          Eigen::aligned_allocator<AnalyticEulerIntegrateFunction>());
     }
     else if (differentiation == "autodiff")
     {
-      return boost::make_shared<AutoDiffEulerIntegrateFunction>();
+      return boost::allocate_shared<AutoDiffEulerIntegrateFunction>(
+          Eigen::aligned_allocator<AutoDiffEulerIntegrateFunction>());
     }
   }
   else if (method == "rungekutta2")
   {
     if (differentiation == "analytic")
     {
-      return boost::make_shared<AnalyticRungeKutta2IntegrateFunction>();
+      return boost::allocate_shared<AnalyticRungeKutta2IntegrateFunction>(
+          Eigen::aligned_allocator<AnalyticRungeKutta2IntegrateFunction>());
     }
     else if (differentiation == "autodiff")
     {
-      return boost::make_shared<AutoDiffRungeKutta2IntegrateFunction>();
+      return boost::allocate_shared<AutoDiffRungeKutta2IntegrateFunction>(
+          Eigen::aligned_allocator<AutoDiffRungeKutta2IntegrateFunction>());
     }
   }
   else if (method == "exact")
   {
     if (differentiation == "analytic")
     {
-      return boost::make_shared<AnalyticExactIntegrateFunction>();
+      return boost::allocate_shared<AnalyticExactIntegrateFunction>(
+          Eigen::aligned_allocator<AnalyticExactIntegrateFunction>());
     }
     else if (differentiation == "autodiff")
     {
-      return boost::make_shared<AutoDiffExactIntegrateFunction>();
+      return boost::allocate_shared<AutoDiffExactIntegrateFunction>(
+          Eigen::aligned_allocator<AutoDiffExactIntegrateFunction>());
     }
   }
 

--- a/diff_drive_controller/src/meas_covariance_model.cpp
+++ b/diff_drive_controller/src/meas_covariance_model.cpp
@@ -50,11 +50,11 @@ MeasCovarianceModel::Ptr MeasCovarianceModel::create(const std::string& model)
 {
   if (model == "linear")
   {
-    return boost::make_shared<LinearMeasCovarianceModel>();
+    return boost::allocate_shared<LinearMeasCovarianceModel>(Eigen::aligned_allocator<LinearMeasCovarianceModel>());
   }
   else if (model == "quadratic")
   {
-    return boost::make_shared<QuadraticMeasCovarianceModel>();
+    return boost::allocate_shared<QuadraticMeasCovarianceModel>(Eigen::aligned_allocator<QuadraticMeasCovarianceModel>());
   }
 
   return Ptr();


### PR DESCRIPTION
This PR does:
1. Add `EIGEN_MAKE_ALIGNED_OPERATOR_NEW`; the `MeasCovariance` `typedef` is an `Eigen::Matrix2d`, which is fixed-sized vectorizable object:
https://eigen.tuxfamily.org/dox/group__TopicFixedSizeVectorizable.html
https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html

2. Use `boost::allocate_shared` w/ `Eigen::aligned_allocator` because `boost::make_shared` (same with `std::` one although we can't use it because we don't use >= C++11 here)  uses the global `operator new` and ignores `EIGEN_MAKE_ALIGNED_OPERATOR_NEW`.
https://www.boost.org/doc/libs/1_43_0/libs/smart_ptr/make_shared.html
http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1049