### PR TITLE
Update last publish time adding period

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -745,7 +745,7 @@ namespace diff_drive_controller
       // same period it was used to compute it.
       odometry_.updateTwist();
 
-      last_odom_publish_time_ = time;
+      last_odom_publish_time_ += publish_period_;
 
       // Populate odom message and publish:
       tf2::Quaternion q;
@@ -777,7 +777,7 @@ namespace diff_drive_controller
       // date with every control cycle and can be published at any rate because
       // it doesn't depend on any period.
 
-      last_odom_tf_publish_time_ = time;
+      last_odom_tf_publish_time_ += publish_period_;
 
       // Populate tf odometry frame message and publish:
       tf2::Quaternion q;


### PR DESCRIPTION
This change is important so we don't ignore the offset between the expected and actual publish time. Otherwise, frequencies that aren't a multiple of the control frequency can never be achieved.

Indeed, this changes makes things match the implementation in the `joint_state_controller`, that is working as intended:
https://github.com/ros-controls/ros_controllers/blob/12a70baee38bf198ad434ad704b353621b23c61a/joint_state_controller/src/joint_state_controller.cpp#L86