### PR TITLE
TOOL-3121: remove .py from xacro script name and --inorder arg

### DIFF
--- a/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_fail_test/ackermann_steering_controller_radius_param_fail.test
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_fail_test/ackermann_steering_controller_radius_param_fail.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro'" />
   <!-- Don't provide the radius parameter, so the controller should break -->
   <!-- <param name="diffbot_controller/wheel_radius" value="0.11"/> -->
 

--- a/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_test/ackermann_steering_controller_radius_param.test
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_test/ackermann_steering_controller_radius_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="ackermann_steering_bot_controller/wheel_radius" value="0.11"/>
 

--- a/ackermann_steering_controller/test/ackermann_steering_controller_separation_param_test/ackermann_steering_controller_separation_param.test
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_separation_param_test/ackermann_steering_controller_separation_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with spere urdf -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="ackermann_steering_bot_controller/wheel_radius" value="0.11"/>
   <!-- Provide the wheel separation -->

--- a/ackermann_steering_controller/test/common/launch/ackermann_steering_common.launch
+++ b/ackermann_steering_controller/test/common/launch/ackermann_steering_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load ackermann_steering_bot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro'" />
 
   <!-- Load controller config -->
   <rosparam command="load" file="$(find ackermann_steering_controller)/test/common/config/ackermann_steering_bot_controllers.yaml" />

--- a/ackermann_steering_controller/test/common/launch/view_ackermann_steering_bot.launch
+++ b/ackermann_steering_controller/test/common/launch/view_ackermann_steering_bot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro'" />
 
   <!-- Load controller config -->
   <rosparam command="load" file="$(find ackermann_steering_controller)/test/common/config/ackermann_steering_bot_controllers.yaml" />

--- a/diff_drive_controller/test/diff_drive_bad_urdf.test
+++ b/diff_drive_controller/test/diff_drive_bad_urdf.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_bad.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_bad.xacro'" />
 
   <!-- Controller test -->
   <test test-name="diff_drive_fail_test"

--- a/diff_drive_controller/test/diff_drive_common.launch
+++ b/diff_drive_controller/test/diff_drive_common.launch
@@ -3,7 +3,7 @@
 
   <!-- Load diffbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/diff_drive_radius_param.test
+++ b/diff_drive_controller/test/diff_drive_radius_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
 

--- a/diff_drive_controller/test/diff_drive_radius_param_fail.test
+++ b/diff_drive_controller/test/diff_drive_radius_param_fail.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Don't provide the radius parameter, so the controller should break -->
   <!-- <param name="diffbot_controller/wheel_radius" value="0.11"/> -->
 

--- a/diff_drive_controller/test/diff_drive_separation_param.test
+++ b/diff_drive_controller/test/diff_drive_separation_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
   <!-- Provide the wheel separation -->

--- a/diff_drive_controller/test/skid_steer_common.launch
+++ b/diff_drive_controller/test/skid_steer_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load skidsteerbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/diff_drive_controller/test/view_diffbot.launch
+++ b/diff_drive_controller/test/view_diffbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/view_skidsteerbot.launch
+++ b/diff_drive_controller/test/view_skidsteerbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/four_wheel_steering_controller/test/launch/four_wheel_steering_common.launch
+++ b/four_wheel_steering_controller/test/launch/four_wheel_steering_common.launch
@@ -4,7 +4,7 @@
 
   <!-- Load four_wheel_steering model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro --inorder '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
+         command="$(find xacro)/xacro '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
 
   <!-- Start four_wheel_steering -->
   <node name="four_wheel_steering"

--- a/four_wheel_steering_controller/test/launch/view_four_wheel_steering.launch
+++ b/four_wheel_steering_controller/test/launch/view_four_wheel_steering.launch
@@ -9,7 +9,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro --inorder '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
+         command="$(find xacro)/xacro '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 

--- a/joint_trajectory_controller/test/joint_trajectory_controller_wrapping.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_wrapping.test
@@ -4,7 +4,7 @@
 
   <!-- Load RRbot model -->
   <param name="robot_description"
-      command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
+      command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
 
   <!-- Start RRbot -->
   <node name="rrbot_wrapping"


### PR DESCRIPTION
The xacro.py script has been deprecated for 5 years and has now been removed in xacro 1.14.4.
The inorder param throws a warning that you don't need it anymore since inorder is the default behaviour now.